### PR TITLE
fix:  Incomplete documentation compilation #20

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -76,5 +76,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          destination_dir: docs/
+          destination_dir: .
           publish_dir: ./docs/build/html


### PR DESCRIPTION
The documentation was updated in owner.github.io/gromo/docs instead of owner.github.io/gromo.