### PR TITLE
fix: `delete_update` function

### DIFF
--- a/src/gromo/growing_module.py
+++ b/src/gromo/growing_module.py
@@ -1194,7 +1194,6 @@ class GrowingModule(torch.nn.Module):
         """
         self.optimal_delta_layer = None
         self.extended_input_layer = None
-        self.extended_output_layer = None
         self.scaling_factor = 0.0  # type: ignore
         # this type problem is due to the use of the setter to change the scaling factor
         self.parameter_update_decrease = None


### PR DESCRIPTION
The function `delete_update` of GrowingModule should not set the attribute `extended_output_layer` to None.
When applying `delete_update` function, the correct behavior shoudl be to set the `extended_input_layer` of the current layer to None, and the `extended_output_layer` of the previous layer to None.

Close #11 