### PR TITLE
!fix: sub_select_optimal_added_parameters 

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -28,6 +28,7 @@ Enhancements
 Bugs
 ~~~~
 
+- Fix the sub-selection of added neurons in the sequential case (:gh:`41` by `Théo Rudkiewicz`_)
 
 API changes
 ~~~~~~~~~~~
@@ -35,3 +36,4 @@ API changes
 
 .. _Sylvain Chevallier: https://github.com/sylvchev
 .. _Stella Douka: https://github.com/stelladk
+.. _Théo Rudkiewicz: https://github.com/TheoRudkiewicz

--- a/src/gromo/growing_module.py
+++ b/src/gromo/growing_module.py
@@ -923,13 +923,25 @@ class GrowingModule(torch.nn.Module):
         if delta_biases is not None:
             self.layer.bias.data += delta_biases
 
+    def _sub_select_added_output_dimension(self, keep_neurons: int) -> None:
+        """
+        Select the first `keep_neurons` neurons of the optimal added output dimension.
+
+        Parameters
+        ----------
+        keep_neurons: int
+            number of neurons to keep
+        """
+        raise NotImplementedError
+
     def sub_select_optimal_added_parameters(
         self,
         keep_neurons: int,
         sub_select_previous: bool = True,
     ) -> None:
         """
-        Select the first keep_neurons neurons of the optimal added parameters.
+        Select the first keep_neurons neurons of the optimal added parameters
+        linked to this layer.
 
         Parameters
         ----------

--- a/src/gromo/linear_growing_module.py
+++ b/src/gromo/linear_growing_module.py
@@ -784,13 +784,35 @@ class LinearGrowingModule(GrowingModule):
             name=self.tensor_m.name,
         )
 
+    def _sub_select_added_output_dimension(self, keep_neurons: int) -> None:
+        """
+        Select the first `keep_neurons` neurons of the optimal added output dimension.
+
+        Parameters
+        ----------
+        keep_neurons: int
+            number of neurons to keep
+        """
+        assert (
+            self.extended_output_layer is not None
+        ), f"The layer should have an extended output layer to sub-select the output dimension."
+        self.extended_output_layer = self.layer_of_tensor(
+            self.extended_output_layer.weight[:keep_neurons],
+            bias=(
+                self.extended_output_layer.bias[:keep_neurons]
+                if self.extended_output_layer.bias is not None
+                else None
+            ),
+        )
+
     def sub_select_optimal_added_parameters(
         self,
         keep_neurons: int,
         sub_select_previous: bool = True,
     ) -> None:
         """
-        Select the first keep_neurons neurons of the optimal added parameters.
+        Select the first keep_neurons neurons of the optimal added parameters
+        linked to this layer.
 
         Parameters
         ----------
@@ -804,7 +826,8 @@ class LinearGrowingModule(GrowingModule):
         ), "The layer should have an extended input xor output layer."
         if self.extended_input_layer is not None:
             self.extended_input_layer = self.layer_of_tensor(
-                self.extended_input_layer.weight[:, :keep_neurons]
+                self.extended_input_layer.weight[:, :keep_neurons],
+                bias=self.extended_input_layer.bias,
             )
             assert self.eigenvalues_extension is not None, (
                 f"The eigenvalues of the extension should be computed before "
@@ -812,18 +835,9 @@ class LinearGrowingModule(GrowingModule):
             )
             self.eigenvalues_extension = self.eigenvalues_extension[:keep_neurons]
 
-        if self.extended_output_layer is not None:
-            self.extended_output_layer = self.layer_of_tensor(
-                self.extended_output_layer.weight[:keep_neurons],
-                bias=(
-                    self.extended_output_layer.bias[:keep_neurons]
-                    if self.extended_output_layer.bias is not None
-                    else None
-                ),
-            )
         if sub_select_previous:
             if isinstance(self.previous_module, LinearGrowingModule):
-                self.previous_module.sub_select_optimal_added_parameters(keep_neurons)
+                self.previous_module._sub_select_added_output_dimension(keep_neurons)
             elif isinstance(self.previous_module, LinearAdditionGrowingModule):
                 raise NotImplementedError
             else:

--- a/tests/test_linear_growing_module.py
+++ b/tests/test_linear_growing_module.py
@@ -473,14 +473,13 @@ class TestLinearGrowingModule(TestCase):
         for bias in {True, False}:
             layer = LinearGrowingModule(3, 1, use_bias=bias, name="layer1")
             layer.extended_output_layer = torch.nn.Linear(3, 2, bias=bias)
-            layer.eigenvalues_extension = torch.tensor([2.0, 1.0])
 
             new_layer = torch.nn.Linear(3, 1, bias=bias)
             new_layer.weight.data = layer.extended_output_layer.weight.data[0].view(1, -1)
             if bias:
                 new_layer.bias.data = layer.extended_output_layer.bias.data[0].view(1)
 
-            layer.sub_select_optimal_added_parameters(1, sub_select_previous=False)
+            layer._sub_select_added_output_dimension(1)
 
             self.assertTrue(
                 torch.allclose(layer.extended_output_layer.weight, new_layer.weight)
@@ -489,11 +488,6 @@ class TestLinearGrowingModule(TestCase):
                 self.assertTrue(
                     torch.allclose(layer.extended_output_layer.bias, new_layer.bias)
                 )
-
-            # self.assertEqual(layer.extended_output_layer, new_layer)
-            self.assertTrue(
-                torch.allclose(layer.eigenvalues_extension, torch.tensor([2.0, 1.0]))
-            )
 
     def test_sub_select_optimal_added_parameters_in(self):
         bias = False

--- a/tests/test_linear_growing_module.py
+++ b/tests/test_linear_growing_module.py
@@ -680,10 +680,10 @@ class TestLinearGrowingModule(TorchTestCase):
                 )
 
                 # those tests are not working yet
-                # demo_layers[1].sub_select_optimal_added_parameters(2)
-                # self.assertEqual(demo_layers[1].eigenvalues_extension.shape[0], 2)
-                # self.assertEqual(demo_layers[1].extended_input_layer.in_features, 2)
-                # self.assertEqual(demo_layers[0].extended_output_layer.out_features, 2)
+                demo_layers[1].sub_select_optimal_added_parameters(2)
+                self.assertEqual(demo_layers[1].eigenvalues_extension.shape[0], 2)
+                self.assertEqual(demo_layers[1].extended_input_layer.in_features, 2)
+                self.assertEqual(demo_layers[0].extended_output_layer.out_features, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The method `sub_select_optimal_added_parameters` now only delete update linked to the current layer (i.e. not output extension) but correctly delete the output of the previous module. Also fixed an infinite loop created when using `sub_select_optimal_added_parameters` with argument `sub_select_previous=True` (its default value).  Hence even this is a breaking change, it change the behavior of a function that was not working properly in most of the cases.

(More unit test have been created that make the bug visible but they are in PR #40)