### PR TITLE
fix: dataset input_shape

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -37,6 +37,7 @@ Bugs
 - Fix the sub-selection of added neurons in the sequential case (:gh:`41` by `Théo Rudkiewicz`_)
 - Correct codecov upload (:gh:`49` by `Sylvain Chevallier`_)
 - Fix the data augmentation bug in get_dataset (:gh:`58` by `Stéphane Rivaud`_)
+- Fix dataset input_shape: remove the flattening in data augmentation (:gh:`56` by `Stéphane Rivaud`_)
 
 API changes
 ~~~~~~~~~~~

--- a/misc/mlp_run.py
+++ b/misc/mlp_run.py
@@ -346,7 +346,7 @@ def main(args: argparse.Namespace):
                 data_augmentation=args.data_augmentation,
                 seed=args.seed,
             )
-            input_shape = train_dataset[0][0].shape[0]
+            input_shape = train_dataset[0][0].shape
 
             pin_memory = device != torch.device("cpu")
             num_workers = 4 if pin_memory else 0

--- a/src/gromo/utils/datasets.py
+++ b/src/gromo/utils/datasets.py
@@ -55,14 +55,14 @@ def get_dataset(
         "mnist": [
             transforms.ToTensor(),
             transforms.Normalize(mnist_mean, mnist_std),
-            transforms.Lambda(lambda x: x.view(-1)),
+            # transforms.Lambda(lambda x: x.view(-1)),
         ],
         "cifar10": [
             transforms.ToTensor(),
             transforms.Normalize(
                 mean=(0.4914, 0.4822, 0.4465), std=(0.2470, 0.2435, 0.2616)
             ),
-            transforms.Lambda(lambda x: x.view(-1)),
+            # transforms.Lambda(lambda x: x.view(-1)),
         ],
     }
     augmentation_transforms = []


### PR DESCRIPTION
Fix dataset input_shape by removing the flattening operation during data-augmentation and replaces it by a flattening operation at the beginning of the forward and extended_forward of GrowingMLP.