### PR TITLE
fix: Fix the value of some default arguments

### DIFF
--- a/misc/mlp_run.py
+++ b/misc/mlp_run.py
@@ -39,7 +39,7 @@ def create_parser() -> argparse.ArgumentParser:
     general_group.add_argument(
         "--log-dir",
         type=str,
-        default="misc/logs",
+        default="logs",
         help="directory to save logs (default: logs)",
     )
     general_group.add_argument(
@@ -51,7 +51,7 @@ def create_parser() -> argparse.ArgumentParser:
     general_group.add_argument(
         "--log-file-name",
         type=str,
-        default=None,
+        default="log",
         help="name of the log file (default: log)",
     )
     general_group.add_argument(


### PR DESCRIPTION
In `mlp_run.py` some arguments have a default value that is not the one indicated by the manual.