### PR TITLE
fix: data augmentation

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -36,11 +36,15 @@ Bugs
 - Fix the change application when updating the previous layer (:gh:`48` by `Théo Rudkiewicz`_)
 - Fix the sub-selection of added neurons in the sequential case (:gh:`41` by `Théo Rudkiewicz`_)
 - Correct codecov upload (:gh:`49` by `Sylvain Chevallier`_)
+- Fix the data augmentation bug in get_dataset (:gh:`58` by `Stéphane Rivaud`_)
 
 API changes
 ~~~~~~~~~~~
+
+- None
 
 
 .. _Sylvain Chevallier: https://github.com/sylvchev
 .. _Stella Douka: https://github.com/stelladk
 .. _Théo Rudkiewicz: https://github.com/TheoRudkiewicz
+.. _Stéphane Rivaud: https://github.com/streethagore

--- a/src/gromo/utils/datasets.py
+++ b/src/gromo/utils/datasets.py
@@ -139,6 +139,5 @@ def get_dataset(
     train_data.dataset.transform = transforms.Compose(
         datasets_transform + augmentation_transforms
     )
-    val_data.dataset.transform = transforms.Compose(datasets_transform)
 
     return train_data, val_data, test_data

--- a/src/gromo/utils/datasets.py
+++ b/src/gromo/utils/datasets.py
@@ -87,7 +87,7 @@ def get_dataset(
         root=dataset_path,
         train=True,
         download=True,
-        transform=None,
+        transform=transforms.Compose(augmentation_transforms + datasets_transform),
     )
 
     test_data = dataset(
@@ -135,9 +135,6 @@ def get_dataset(
         torch.manual_seed(seed)
     train_data, val_data = torch.utils.data.random_split(
         train_val_data, [train_size, val_size]
-    )
-    train_data.dataset.transform = transforms.Compose(
-        datasets_transform + augmentation_transforms
     )
 
     return train_data, val_data, test_data


### PR DESCRIPTION
Currently, the way data augmentation is set on the validation set erases the augmentation set for the training set because train_dataset and val_dataset are instances of a `Subset` class, which points to the same dataset: https://pytorch.org/docs/stable/_modules/torch/utils/data/dataset.html#Subset

Thus, when setting the augmentation for the validation set, it automatically sets the same augmentation for the training set.
Currently, as we do not apply augmentation on the validation set, this means that the augmentation was not applied to the training set.
Experiments should be ran again to look for direct improvements.

I decided to apply data augmentation on both train and validation set, for ease of implementation.
If a more fine-grained control over data augmentation is needed, I will need to update the pull request.