### PR TITLE
fix: Default `preferred_linalg_library`

### DIFF
--- a/src/gromo/utils/tools.py
+++ b/src/gromo/utils/tools.py
@@ -6,7 +6,7 @@ import torch
 def sqrt_inverse_matrix_semi_positive(
     matrix: torch.Tensor,
     threshold: float = 1e-5,
-    preferred_linalg_library: None | str = "magma",
+    preferred_linalg_library: None | str = None,
 ) -> torch.Tensor:
     """
     Compute the square root of the inverse of a semi-positive definite matrix.


### PR DESCRIPTION
Changes default value for `preferred_linalg_library` in `sqrt_inverse_matrix_semi_positive`. Since the value of `preferred_linalg_library` can now be handled via the introduced config file mechanism, `None` should be the default value in this function.