### PR TITLE
enh: Slightly optimize computation of tensor S

### DIFF
--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -243,11 +243,12 @@ class Conv2dGrowingModule(GrowingModule):
         assert (
             self.input is not None
         ), f"The input must be stored to compute the update of S. (error in {self.name})"
+        unfolded_extended_input = self.unfolded_extended_input
         return (
             torch.einsum(
                 "iam, ibm -> ab",
-                self.unfolded_extended_input,
-                self.unfolded_extended_input,
+                unfolded_extended_input,
+                unfolded_extended_input,
             ),
             self.input.shape[0],
         )
@@ -385,13 +386,14 @@ class Conv2dGrowingModule(GrowingModule):
         int
             number of samples used to compute the update
         """
+        masked_unfolded_prev_input = self.masked_unfolded_prev_input
         return (
             torch.einsum(
                 "ijea, ijeb -> ab",
-                self.masked_unfolded_prev_input,
-                self.masked_unfolded_prev_input,
+                masked_unfolded_prev_input,
+                masked_unfolded_prev_input,
             ),
-            self.masked_unfolded_prev_input.shape[0],
+            masked_unfolded_prev_input.shape[0],
         )
 
     @property

--- a/src/gromo/modules/linear_growing_module.py
+++ b/src/gromo/modules/linear_growing_module.py
@@ -433,11 +433,12 @@ class LinearGrowingModule(GrowingModule):
         assert (
             self.input is not None
         ), f"The input must be stored to compute the update of S. (error in {self.name})"
+        input_extended = self.input_extended
         return (
             torch.einsum(
                 "ij,ik->jk",
-                torch.flatten(self.input_extended, 0, -2),
-                torch.flatten(self.input_extended, 0, -2),
+                torch.flatten(input_extended, 0, -2),
+                torch.flatten(input_extended, 0, -2),
             ),
             torch.tensor(self.input.shape[:-1]).prod().int().item(),
         )


### PR DESCRIPTION
To compute `S` we need the input tensor extended with ones. Instead of constructing it twice we construct it only one. This is related to issue #83  (but it does not fix it).