### PR TITLE
fix: Use the correct name for the tensor statistics

### DIFF
--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -51,7 +51,7 @@ class AdditionGrowingModule(torch.nn.Module):
             tensor_s_shape,
             update_function=self.compute_s_update,
             device=self.device,
-            name=f"S({name})",
+            name=f"S({self.name})",
         )
 
         self.previous_tensor_s: TensorStatistic | None = None
@@ -476,13 +476,13 @@ class GrowingModule(torch.nn.Module):
             tensor_s_shape,
             update_function=self.compute_s_update,
             device=self.device,
-            name=f"S({name})",
+            name=f"S({self.name})",
         )
         self.tensor_m = TensorStatistic(
             tensor_m_shape,
             update_function=self.compute_m_update,
             device=self.device,
-            name=f"M({name})",
+            name=f"M({self.name})",
         )
         # self.tensor_n = TensorStatistic(output_shape, update_function=self.compute_n_update)
 
@@ -513,13 +513,13 @@ class GrowingModule(torch.nn.Module):
             None,
             update_function=self.compute_m_prev_update,
             device=self.device,
-            name=f"M_prev({name})",
+            name=f"M_prev({self.name})",
         )
         self.cross_covariance = TensorStatistic(
             None,
             update_function=self.compute_cross_covariance_update,
             device=self.device,
-            name=f"C({name})",
+            name=f"C({self.name})",
         )
 
         self.s_growth_is_needed = s_growth_is_needed


### PR DESCRIPTION
Tensor statistics that are linked to a specific module have a name that contains the name of the module. This is mainly used for debugging. Before this fix it was not using the true name of the module but only the part that is defined by the user and that is none by default.