### PR TITLE
Optimize restricted fogro

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -20,6 +20,7 @@ Develop branch
 Enhancements
 ~~~~~~~~~~~~
 
+- Optimize RestrictedConv2dGrowingModule to fasten the simulation of the side effect of a convolution (:gh:`99` by `Théo Rudkiewicz`_).
 - Split Conv2dGrowingModule into two subclass `FullConv2dGrowingModule`(that does the same as the previous class) and  `RestrictedConv2dGrowingModule` (that compute only the best 1x1 convolution as the second layer at growth time) (:gh:`92` by `Théo Rudkiewicz`_).
 - Code factorization of methods `compute_optimal_added_parameters` and `compute_optimal_delta` that are now abstracted in the `GrowingModule` class. (:gh:`87` by `Théo Rudkiewicz`_).
 - Stops automatically computing parameter update in `Conv2dGrowingModule.compute_optimal_added_parameters`to be consistent with `LinearGrowingModule.compute_optimal_added_parameters` (:gh:`87` by `Théo Rudkiewicz`_) .

--- a/src/gromo/utils/tools.py
+++ b/src/gromo/utils/tools.py
@@ -231,11 +231,59 @@ def compute_mask_tensor_t(
     return tensor_t
 
 
-@torch.no_grad
+def create_bordering_effect_convolution(
+    channels: int,
+    convolution: torch.nn.Conv2d,
+) -> torch.nn.Conv2d:
+    """
+    Create a convolution that simulates the border effect of a convolution
+    on an unfolded tensor. The convolution can then be used in
+    `apply_border_effect_on_unfolded`.
+
+    Parameters
+    ----------
+    channels: int
+        Number of input channels for the convolution, warning
+        this is for the unfolded tensor, not the original tensor.
+        Therefore, it should be equal to C[-1] * C1.kernel_size[0] * C1.kernel_size[1].
+    convolution: torch.nn.Conv2d
+        convolutional layer to be applied on the unfolded tensor
+
+    Returns
+    -------
+    torch.nn.Conv2d
+        convolutional layer that simulates the border effect
+    """
+    if not isinstance(channels, int) or channels <= 0:
+        raise ValueError("Input 'input_channels' must be a positive integer.")
+    if not isinstance(convolution, torch.nn.Conv2d):
+        raise TypeError("Input 'convolution' must be a torch.nn.Conv2d instance.")
+
+    identity_conv = torch.nn.Conv2d(
+        in_channels=channels,
+        out_channels=channels,
+        groups=channels,
+        kernel_size=convolution.kernel_size,
+        padding=convolution.padding,
+        stride=convolution.stride,
+        dilation=convolution.dilation,
+        bias=False,
+        device=convolution.weight.device,
+    )
+
+    identity_conv.weight.data.fill_(0)
+    mid = (convolution.kernel_size[0] // 2, convolution.kernel_size[1] // 2)
+    identity_conv.weight.data[:, 0, mid[0], mid[1]] = 1.0
+
+    return identity_conv
+
+
+@torch.no_grad()
 def apply_border_effect_on_unfolded(
     unfolded_tensor: torch.Tensor,
     original_size: tuple[int, int],
-    border_effect_conv: torch.nn.Conv2d,
+    border_effect_conv: torch.nn.Conv2d | None = None,
+    identity_conv: torch.nn.Conv2d | None = None,
 ) -> torch.Tensor:
     """
     Simulate the effect of a 1x1 convolution on the size of an unfolded tensor.
@@ -257,6 +305,9 @@ def apply_border_effect_on_unfolded(
         original size of the tensor before unfolding
     border_effect_conv: torch.Conv2d
         convolutional layer to be applied on the unfolded tensor
+    identity_conv: torch.Conv2d
+        convolutional layer that simulates the identity effect,
+        if None, it will be created from `border_effect_conv`.
 
     Returns
     -------
@@ -265,23 +316,16 @@ def apply_border_effect_on_unfolded(
     """
     if not isinstance(unfolded_tensor, torch.Tensor):
         raise TypeError("Input 'unfolded_tensor' must be a torch.Tensor")
+    assert isinstance(border_effect_conv, torch.nn.Conv2d) or isinstance(
+        identity_conv, torch.nn.Conv2d
+    ), "Either 'border_effect_conv' or 'identity_conv' must be provided."
 
-    channels = unfolded_tensor.shape[1]
-    identity_conv = torch.nn.Conv2d(
-        in_channels=channels,
-        out_channels=channels,
-        groups=channels,
-        kernel_size=border_effect_conv.kernel_size,
-        padding=border_effect_conv.padding,
-        stride=border_effect_conv.stride,
-        dilation=border_effect_conv.dilation,
-        bias=False,
-        device=unfolded_tensor.device,
-    )
-
-    identity_conv.weight.data.fill_(0)
-    mid = (border_effect_conv.kernel_size[0] // 2, border_effect_conv.kernel_size[1] // 2)
-    identity_conv.weight.data[:, 0, mid[0], mid[1]] = 1.0
+    if identity_conv is None:
+        channels = unfolded_tensor.shape[1]
+        identity_conv = create_bordering_effect_convolution(
+            channels=channels,
+            convolution=border_effect_conv,
+        )
 
     unfolded_tensor = unfolded_tensor.reshape(
         unfolded_tensor.shape[0],

--- a/src/gromo/utils/tools.py
+++ b/src/gromo/utils/tools.py
@@ -276,12 +276,12 @@ def apply_border_effect_on_unfolded(
         stride=border_effect_conv.stride,
         dilation=border_effect_conv.dilation,
         bias=False,
+        device=unfolded_tensor.device,
     )
 
     identity_conv.weight.data.fill_(0)
     mid = (border_effect_conv.kernel_size[0] // 2, border_effect_conv.kernel_size[1] // 2)
     identity_conv.weight.data[:, 0, mid[0], mid[1]] = 1.0
-    identity_conv.weight.data = identity_conv.weight.data.to(unfolded_tensor.device)
 
     unfolded_tensor = unfolded_tensor.reshape(
         unfolded_tensor.shape[0],


### PR DESCRIPTION
We avoid creating a big convolution to compute the side effect of a convolution on a unfolded image. To do this we change two things:
- use a grouped convolution
- create the convolution only once and then use it

This can reduce the neuron addition cost by a factor ~5 to 10.