### PR TITLE
fix: Fix `tensor_n` in `RestrictedConv2dGrowingModule`

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -20,6 +20,7 @@ Develop branch
 Enhancements
 ~~~~~~~~~~~~
 
+- Fix the `tensor_n` computation in RestrictedConv2dGrowingModule` (:gh:`103` by `Théo Rudkiewicz`_).
 - Optimize RestrictedConv2dGrowingModule to fasten the simulation of the side effect of a convolution (:gh:`99` by `Théo Rudkiewicz`_).
 - Split Conv2dGrowingModule into two subclass `FullConv2dGrowingModule`(that does the same as the previous class) and  `RestrictedConv2dGrowingModule` (that compute only the best 1x1 convolution as the second layer at growth time) (:gh:`92` by `Théo Rudkiewicz`_).
 - Code factorization of methods `compute_optimal_added_parameters` and `compute_optimal_delta` that are now abstracted in the `GrowingModule` class. (:gh:`87` by `Théo Rudkiewicz`_).

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -20,7 +20,7 @@ Develop branch
 Enhancements
 ~~~~~~~~~~~~
 
-- Fix the `tensor_n` computation in RestrictedConv2dGrowingModule` (:gh:`103` by `Théo Rudkiewicz`_).
+- Fix the `tensor_n` computation in `RestrictedConv2dGrowingModule` (:gh:`103` by `Théo Rudkiewicz`_).
 - Optimize RestrictedConv2dGrowingModule to fasten the simulation of the side effect of a convolution (:gh:`99` by `Théo Rudkiewicz`_).
 - Split Conv2dGrowingModule into two subclass `FullConv2dGrowingModule`(that does the same as the previous class) and  `RestrictedConv2dGrowingModule` (that compute only the best 1x1 convolution as the second layer at growth time) (:gh:`92` by `Théo Rudkiewicz`_).
 - Code factorization of methods `compute_optimal_added_parameters` and `compute_optimal_delta` that are now abstracted in the `GrowingModule` class. (:gh:`87` by `Théo Rudkiewicz`_).

--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -781,7 +781,7 @@ class RestrictedConv2dGrowingModule(Conv2dGrowingModule):
             self.delta_raw, torch.Tensor
         ), f"The optimal delta should be a tensor for {self.name}, is {type(self.delta_raw)}."
         assert (
-            self.delta_raw.shape[0]
+            self.delta_raw.shape[1]
             == self.in_channels * self.kernel_size[0] * self.kernel_size[1]
             + self.use_bias
         ), (
@@ -789,10 +789,10 @@ class RestrictedConv2dGrowingModule(Conv2dGrowingModule):
             f" but got {self.delta_raw.shape}."
         )
         assert (
-            self.delta_raw.shape[1] == self.out_channels
+            self.delta_raw.shape[0] == self.out_channels
         ), f"The delta should have shape ({self.out_channels}, ...) but got {self.delta_raw.shape}."
         return -self.tensor_m_prev() - torch.einsum(
-            "ab, bc -> ac", self.cross_covariance(), self.delta_raw
+            "ab, cb -> ac", self.cross_covariance(), self.delta_raw
         )
 
     def compute_optimal_added_parameters(

--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -785,8 +785,8 @@ class RestrictedConv2dGrowingModule(Conv2dGrowingModule):
             == self.in_channels * self.kernel_size[0] * self.kernel_size[1]
             + self.use_bias
         ), (
-            f"The delta should have shape ({self.in_channels * self.kernel_size[0] * self.kernel_size[1] + self.use_bias}, ...)"
-            f" but got {self.delta_raw.shape}."
+            f"Expected delta_raw.shape[1] == {self.in_channels * self.kernel_size[0] * self.kernel_size[1] + self.use_bias}, "
+            f"but got {self.delta_raw.shape[1]} (full shape: {self.delta_raw.shape})."
         )
         assert (
             self.delta_raw.shape[0] == self.out_channels

--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -790,7 +790,7 @@ class RestrictedConv2dGrowingModule(Conv2dGrowingModule):
         )
         assert (
             self.delta_raw.shape[0] == self.out_channels
-        ), f"The delta should have shape ({self.out_channels}, ...) but got {self.delta_raw.shape}."
+        ), f"Expected delta_raw.shape[0] == {self.out_channels}, but got {self.delta_raw.shape[0]}."
         return -self.tensor_m_prev() - torch.einsum(
             "ab, cb -> ac", self.cross_covariance(), self.delta_raw
         )


### PR DESCRIPTION
Test `test_tensor_n_computation` for `RestrictedConv2dGrowingModule` was incorrect. Indeed the `delta_raw` was artificially created with a wrong shape (as can be seen in the shape checked in `test_compute_optimal_delta`). Now the test is correct which leads to a bug in `tensor_n` which is been fixed here.