### PR TITLE
feat: Add an option to compute the new neurons with `tensor_m_prev` instead of `tensor_n`

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -20,6 +20,7 @@ Develop branch
 Enhancements
 ~~~~~~~~~~~~
 
+- Add `use_projected_gradient` parameter to growing modules to control whether to use projected gradient (`tensor_n`) or raw tensor (`tensor_m_prev`) for computing new neurons. This provides more flexibility in the optimization strategy and improves test coverage for critical code paths (:gh:`104` by `Théo Rudkiewicz`_).
 - Fix statistics normalization in `LinearGrowingModule` (:gh:`110` by `Stéphane Rivaud`_)
 - Implement systematic test coverage improvement initiative achieving 92% → 95% overall coverage through 4-phase strategic enhancement targeting critical modules: utils.py (80% → 96%), tools.py (78% → 98%), and growing_module.py (92% → 94%). Added 27 comprehensive test methods covering multi-device compatibility, error handling paths, mathematical algorithm edge cases, and abstract class testing via concrete implementations (:gh:`113` by `Stéphane Rivaud`_).
 - Fix the `tensor_n` computation in `RestrictedConv2dGrowingModule` (:gh:`103` by `Théo Rudkiewicz`_).

--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -802,6 +802,7 @@ class RestrictedConv2dGrowingModule(Conv2dGrowingModule):
         maximum_added_neurons: int | None = None,
         update_previous: bool = True,
         dtype: torch.dtype = torch.float32,
+        use_projected_gradient: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
         """
         Compute the optimal added parameters to extend the input layer.
@@ -818,6 +819,8 @@ class RestrictedConv2dGrowingModule(Conv2dGrowingModule):
             whether to change the previous layer extended_output_layer
         dtype: torch.dtype
             dtype for S and N during the computation
+        use_projected_gradient: bool
+            whereas to use the projected gradient ie `tensor_n` or the raw `tensor_m`
 
         Returns
         -------
@@ -829,6 +832,7 @@ class RestrictedConv2dGrowingModule(Conv2dGrowingModule):
             statistical_threshold=statistical_threshold,
             maximum_added_neurons=maximum_added_neurons,
             dtype=dtype,
+            use_projected_gradient=use_projected_gradient,
         )
 
         k = self.eigenvalues_extension.shape[0]

--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -1034,7 +1034,7 @@ class FullConv2dGrowingModule(Conv2dGrowingModule):
                     "ixab, icx -> bca",
                     self.masked_unfolded_prev_input,
                     desired_activation,
-                ),
+                ).flatten(start_dim=-2),
                 desired_activation.shape[0],
             )
         elif isinstance(self.previous_module, Conv2dMergeGrowingModule):
@@ -1125,9 +1125,8 @@ class FullConv2dGrowingModule(Conv2dGrowingModule):
         assert (
             self.delta_raw is not None
         ), f"The optimal delta should be computed before the tensor N for {self.name}."
-        return (
-            -self.tensor_m_prev()
-            - torch.einsum("abe, ce -> bca", self.cross_covariance(), self.delta_raw)
+        return -self.tensor_m_prev() - torch.einsum(
+            "abe, ce -> bca", self.cross_covariance(), self.delta_raw
         ).flatten(start_dim=-2)
 
     def compute_optimal_added_parameters(
@@ -1137,6 +1136,7 @@ class FullConv2dGrowingModule(Conv2dGrowingModule):
         maximum_added_neurons: int | None = None,
         update_previous: bool = True,
         dtype: torch.dtype = torch.float32,
+        use_projected_gradient: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
         """
         Compute the optimal added parameters to extend the input layer.
@@ -1153,6 +1153,8 @@ class FullConv2dGrowingModule(Conv2dGrowingModule):
             whether to change the previous layer extended_output_layer
         dtype: torch.dtype
             dtype for S and N during the computation
+        use_projected_gradient: bool
+            whereas to use the projected gradient ie `tensor_n` or the raw `tensor_m`
 
         Returns
         -------
@@ -1164,6 +1166,7 @@ class FullConv2dGrowingModule(Conv2dGrowingModule):
             statistical_threshold=statistical_threshold,
             maximum_added_neurons=maximum_added_neurons,
             dtype=dtype,
+            use_projected_gradient=use_projected_gradient,
         )
 
         k = self.eigenvalues_extension.shape[0]

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -1389,7 +1389,6 @@ class GrowingModule(torch.nn.Module):
         statistical_threshold: float = 1e-5,
         maximum_added_neurons: int | None = None,
         update_previous: bool = True,
-        zero_delta: bool = False,
         dtype: torch.dtype = torch.float32,
         use_projected_gradient: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
@@ -1406,8 +1405,6 @@ class GrowingModule(torch.nn.Module):
             maximum number of added neurons, if None all significant neurons are kept
         update_previous: bool
             whether to change the previous layer extended_output_layer
-        zero_delta: bool
-            if True, compute the optimal added neurons without performing the natural gradient step.
         dtype: torch.dtype
             dtype for the computation of the optimal delta and added parameters
         use_projected_gradient: bool
@@ -1419,12 +1416,6 @@ class GrowingModule(torch.nn.Module):
             optimal extension for the previous layer (weights and biases)
         """
         self.compute_optimal_delta(dtype=dtype)
-        if zero_delta:
-            if self.optimal_delta_layer is not None:
-                self.optimal_delta_layer.weight.data.zero_()
-                if self.optimal_delta_layer.bias is not None:
-                    self.optimal_delta_layer.bias.data.zero_()
-            self.delta_raw.zero_()
 
         if self.previous_module is None:
             return  # FIXME: change the definition of the function

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -1258,6 +1258,7 @@ class GrowingModule(torch.nn.Module):
         statistical_threshold: float = 1e-3,
         maximum_added_neurons: int | None = None,
         dtype: torch.dtype = torch.float32,
+        use_projected_gradient: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Auxiliary function to compute the optimal added parameters (alpha, omega, k)
@@ -1272,13 +1273,18 @@ class GrowingModule(torch.nn.Module):
             maximum number of added neurons, if None all significant neurons are kept
         dtype: torch.dtype
             dtype for S and N during the computation
+        use_projected_gradient: bool
+            whereas to use the projected gradient ie `tensor_n` or the raw `tensor_m`
 
         Returns
         -------
         tuple[torch.Tensor, torch.Tensor, torch.Tensor]
             optimal added weights alpha, omega and eigenvalues lambda
         """
-        matrix_n = self.tensor_n
+        if use_projected_gradient:
+            matrix_n = self.tensor_n
+        else:
+            matrix_n = self.tensor_m_prev()
         # It seems that sometimes the tensor N is not accessible.
         # I have no idea why this occurs sometimes.
 
@@ -1314,6 +1320,7 @@ class GrowingModule(torch.nn.Module):
         maximum_added_neurons: int | None = None,
         update_previous: bool = True,
         dtype: torch.dtype = torch.float32,
+        use_projected_gradient: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
         """
         Compute the optimal added parameters to extend the input layer.
@@ -1331,6 +1338,8 @@ class GrowingModule(torch.nn.Module):
             whether to change the previous layer extended_output_layer
         dtype: torch.dtype
             dtype for S and N during the computation
+        use_projected_gradient: bool
+            whereas to use the projected gradient ie `tensor_n` or the raw `tensor_m`
 
         Returns
         -------
@@ -1369,6 +1378,7 @@ class GrowingModule(torch.nn.Module):
         update_previous: bool = True,
         zero_delta: bool = False,
         dtype: torch.dtype = torch.float32,
+        use_projected_gradient: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
         """
         Compute the optimal update  and additional neurons.
@@ -1387,6 +1397,8 @@ class GrowingModule(torch.nn.Module):
             if True, compute the optimal added neurons without performing the natural gradient step.
         dtype: torch.dtype
             dtype for the computation of the optimal delta and added parameters
+        use_projected_gradient: bool
+            whereas to use the projected gradient ie `tensor_n` or the raw `tensor_m`
 
         Returns
         -------
@@ -1410,6 +1422,7 @@ class GrowingModule(torch.nn.Module):
                 maximum_added_neurons=maximum_added_neurons,
                 update_previous=update_previous,
                 dtype=dtype,
+                use_projected_gradient=use_projected_gradient,
             )
             return alpha_weight, alpha_bias
         elif isinstance(self.previous_module, MergeGrowingModule):

--- a/src/gromo/modules/linear_growing_module.py
+++ b/src/gromo/modules/linear_growing_module.py
@@ -915,6 +915,7 @@ class LinearGrowingModule(GrowingModule):
         maximum_added_neurons: int | None = None,
         update_previous: bool = True,
         dtype: torch.dtype = torch.float32,
+        use_projected_gradient: bool = True,
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
         """
         Compute the optimal added parameters to extend the input layer.
@@ -931,6 +932,8 @@ class LinearGrowingModule(GrowingModule):
             whether to change the previous layer extended_output_layer
         dtype: torch.dtype
             dtype for S and N during the computation
+        use_projected_gradient: bool
+            whereas to use the projected gradient ie `tensor_n` or the raw `tensor_m`
 
         Returns
         -------
@@ -942,6 +945,7 @@ class LinearGrowingModule(GrowingModule):
             statistical_threshold=statistical_threshold,
             maximum_added_neurons=maximum_added_neurons,
             dtype=dtype,
+            use_projected_gradient=use_projected_gradient,
         )
         k = self.eigenvalues_extension.shape[0]
         assert alpha.shape[0] == omega.shape[1], (

--- a/tests/test_conv2d_growing_module.py
+++ b/tests/test_conv2d_growing_module.py
@@ -627,7 +627,9 @@ class TestFullConv2dGrowingModule(TestConv2dGrowingModule):
         self.assertEqual(demo_couple[0].extended_output_layer.out_channels, 3)
 
         @unittest_parametrize(({"bias": True}, {"bias": False}))
-        def test_compute_optimal_added_parameters_use_projected_gradient_false(self, bias: bool):
+        def test_compute_optimal_added_parameters_use_projected_gradient_false(
+            self, bias: bool
+        ):
             """
             Explicitly test the use_projected_gradient=False branch for coverage.
             """
@@ -646,7 +648,9 @@ class TestFullConv2dGrowingModule(TestConv2dGrowingModule):
 
             # demo_couple[1].compute_optimal_delta()
             # Call with use_projected_gradient=False
-            alpha, alpha_b, omega, eigenvalues = demo_couple[1].compute_optimal_added_parameters(use_projected_gradient=False)
+            alpha, alpha_b, omega, eigenvalues = demo_couple[
+                1
+            ].compute_optimal_added_parameters(use_projected_gradient=False)
 
             self.assertShapeEqual(
                 alpha,

--- a/tests/test_conv2d_growing_module.py
+++ b/tests/test_conv2d_growing_module.py
@@ -472,12 +472,15 @@ class TestFullConv2dGrowingModule(TestConv2dGrowingModule):
                 s0 = demo_couple[0].in_channels * demo_couple[0].kernel_size[
                     0
                 ] * demo_couple[0].kernel_size[1] + (1 if bias else 0)
-                s1 = demo_couple[1].out_channels
-                s2 = demo_couple[1].kernel_size[0] * demo_couple[1].kernel_size[1]
+                s1 = (
+                    demo_couple[1].out_channels
+                    * demo_couple[1].kernel_size[0]
+                    * demo_couple[1].kernel_size[1]
+                )
 
                 self.assertShapeEqual(
                     demo_couple[1].tensor_m_prev(),
-                    (s0, s1, s2),
+                    (s0, s1),
                 )
 
     def test_cross_covariance_update(self):
@@ -580,8 +583,9 @@ class TestFullConv2dGrowingModule(TestConv2dGrowingModule):
 
         m_prev_shape_theory = (
             s_shape_theory,
-            demo_couple[1].out_channels,
-            demo_couple[1].kernel_size[0] * demo_couple[1].kernel_size[1],
+            demo_couple[1].out_channels
+            * demo_couple[1].kernel_size[0]
+            * demo_couple[1].kernel_size[1],
         )
         self.assertShapeEqual(demo_couple[1].tensor_m_prev(), m_prev_shape_theory)
 
@@ -626,58 +630,54 @@ class TestFullConv2dGrowingModule(TestConv2dGrowingModule):
         self.assertEqual(demo_couple[1].extended_input_layer.in_channels, 3)
         self.assertEqual(demo_couple[0].extended_output_layer.out_channels, 3)
 
-        @unittest_parametrize(({"bias": True}, {"bias": False}))
-        def test_compute_optimal_added_parameters_use_projected_gradient_false(
-            self, bias: bool
-        ):
-            """
-            Explicitly test the use_projected_gradient=False branch for coverage.
-            """
-            demo_couple = self.demo_couple[bias]
-            # demo_couple[0].store_input = True
-            demo_couple[1].init_computation()
-            # demo_couple[1].tensor_s_growth.init()
+    @unittest_parametrize(({"bias": True}, {"bias": False}))
+    def test_compute_optimal_added_parameters_use_projected_gradient_false(
+        self, bias: bool
+    ):
+        """
+        Explicitly test the use_projected_gradient=False branch for coverage.
+        """
+        demo_couple = self.demo_couple[bias]
+        demo_couple[1].init_computation()
 
-            y = demo_couple[0](self.input_x)
-            y = demo_couple[1](y)
-            loss = torch.norm(y)
-            loss.backward()
+        y = demo_couple[0](self.input_x)
+        y = demo_couple[1](y)
+        loss = torch.norm(y)
+        loss.backward()
 
-            demo_couple[1].update_computation()
-            # demo_couple[1].tensor_s_growth.update()
+        demo_couple[1].update_computation()
 
-            # demo_couple[1].compute_optimal_delta()
-            # Call with use_projected_gradient=False
-            alpha, alpha_b, omega, eigenvalues = demo_couple[
-                1
-            ].compute_optimal_added_parameters(use_projected_gradient=False)
+        # Call with use_projected_gradient=False
+        alpha, alpha_b, omega, eigenvalues = demo_couple[
+            1
+        ].compute_optimal_added_parameters(use_projected_gradient=False)
 
-            self.assertShapeEqual(
-                alpha,
-                (
-                    -1,
-                    demo_couple[0].in_channels,
-                    demo_couple[0].kernel_size[0],
-                    demo_couple[0].kernel_size[1],
-                ),
-            )
-            k = alpha.size(0)
-            if bias:
-                self.assertShapeEqual(alpha_b, (k,))
-            else:
-                self.assertIsNone(alpha_b)
+        self.assertShapeEqual(
+            alpha,
+            (
+                -1,
+                demo_couple[0].in_channels,
+                demo_couple[0].kernel_size[0],
+                demo_couple[0].kernel_size[1],
+            ),
+        )
+        k = alpha.size(0)
+        if bias:
+            self.assertShapeEqual(alpha_b, (k,))
+        else:
+            self.assertIsNone(alpha_b)
 
-            self.assertShapeEqual(
-                omega,
-                (
-                    demo_couple[1].out_channels,
-                    k,
-                    demo_couple[1].kernel_size[0],
-                    demo_couple[1].kernel_size[1],
-                ),
-            )
+        self.assertShapeEqual(
+            omega,
+            (
+                demo_couple[1].out_channels,
+                k,
+                demo_couple[1].kernel_size[0],
+                demo_couple[1].kernel_size[1],
+            ),
+        )
 
-            self.assertShapeEqual(eigenvalues, (k,))
+        self.assertShapeEqual(eigenvalues, (k,))
 
     @unittest_parametrize(({"bias": True}, {"bias": False}))
     def test_compute_optimal_added_parameters_empirical(self, bias: bool):
@@ -717,7 +717,7 @@ class TestFullConv2dGrowingModule(TestConv2dGrowingModule):
         demo_couple[1].delta_raw *= 0
 
         self.assertAllClose(
-            -demo_couple[1].tensor_m_prev().flatten(start_dim=-2),
+            -demo_couple[1].tensor_m_prev(),
             demo_couple[1].tensor_n,
             message="The tensor_m_prev should be equal to the tensor_n when the delta is zero",
         )
@@ -905,6 +905,42 @@ class TestRestrictedConv2dGrowingModule(TestConv2dGrowingModule):
         )
 
         alpha, alpha_b, omega, eigs = demo_out.compute_optimal_added_parameters()
+
+        self.assertIsInstance(alpha, torch.Tensor)
+        self.assertIsInstance(omega, torch.Tensor)
+        self.assertIsInstance(eigs, torch.Tensor)
+        if bias:
+            self.assertIsInstance(alpha_b, torch.Tensor)
+        else:
+            self.assertIsNone(alpha_b)
+
+    @unittest_parametrize(({"bias": True}, {"bias": False}))
+    def test_compute_optimal_added_parameters_use_projected_gradient_false(
+        self, bias: bool
+    ):
+        """Test compute_optimal_added_parameters with use_projected_gradient=False for RestrictedConv2dGrowingModule."""
+        demo_in, demo_out = self.demo_couple[bias]
+
+        demo_out.init_computation()
+
+        x = demo_in(self.input_x)
+        y = demo_out(x)
+        loss = torch.nn.functional.mse_loss(y, torch.zeros_like(y))
+        loss.backward()
+
+        demo_out.update_computation()
+
+        demo_out.delta_raw = torch.zeros(
+            demo_out.out_channels,
+            demo_out.in_channels * demo_out.kernel_size[0] * demo_out.kernel_size[1]
+            + bias,
+            device=global_device(),
+        )
+
+        # Test with use_projected_gradient=False
+        alpha, alpha_b, omega, eigs = demo_out.compute_optimal_added_parameters(
+            use_projected_gradient=False
+        )
 
         self.assertIsInstance(alpha, torch.Tensor)
         self.assertIsInstance(omega, torch.Tensor)

--- a/tests/test_linear_growing_module.py
+++ b/tests/test_linear_growing_module.py
@@ -962,9 +962,6 @@ class TestLinearGrowingModule(TestLinearGrowingModuleBase):
             layer_out.compute_optimal_updates()
             self.verify_layer_invariants(layer_out, reference, invariants)
 
-        # Test update without natural gradient
-        layer_out.compute_optimal_updates(zero_delta=True)
-
     @unittest_parametrize(({"bias": True, "dtype": torch.float64}, {"bias": False}))
     def test_compute_optimal_added_parameters(
         self, bias: bool, dtype: torch.dtype = torch.float32


### PR DESCRIPTION
In practice this means ignoring the projection gradient step. This is a cleaner option the zeroing the `delta_raw` but I did not remove this option to avoid breaking change. This is also useful in the case where we add residual block and there is no existing parameter in the block to update.
Maybe we could remove the `zero_delta` option, I let @stephane-rivaud decide if he agrees.