### PR TITLE
enh: optional flattening in GrowingMLP

### DIFF
--- a/src/gromo/containers/growing_mlp.py
+++ b/src/gromo/containers/growing_mlp.py
@@ -14,12 +14,13 @@ class GrowingMLP(GrowingContainer):
 
     def __init__(
         self,
-        in_features: int,
+        in_features: int | list | tuple,
         out_features: int,
         hidden_size: int,
         number_hidden_layers: int,
         activation: nn.Module = nn.SELU(),
         use_bias: bool = True,
+        flatten: bool = True,
         device: Optional[torch.device] = None,
     ) -> None:
         """
@@ -46,10 +47,20 @@ class GrowingMLP(GrowingContainer):
             in_features=in_features, out_features=out_features, device=device
         )
 
-        self.num_features = torch.tensor(self.in_features).prod().int().item()
+        if isinstance(self.in_features, int):
+            self.num_features = self.in_features
+        elif isinstance(self.in_features, (list, tuple)):
+            if flatten:
+                self.num_features = torch.tensor(self.in_features).prod().int().item()
+            else:
+                self.num_features = self.in_features[-1]
+        else:
+            raise TypeError(
+                f"Expected in_features to be int, list, or tuple, got {type(self.in_features)}"
+            )
 
         # Flatten input
-        self.flatten = nn.Flatten(start_dim=1)
+        self.flatten = nn.Flatten(start_dim=1) if flatten else nn.Identity()
         self.layers = nn.ModuleList()
         self.layers.append(
             LinearGrowingModule(
@@ -214,6 +225,7 @@ class Perceptron(GrowingMLP):
         out_features: int,
         activation: nn.Module = nn.Sigmoid(),
         use_bias: bool = True,
+        flatten: bool = True,
         device: Optional[torch.device] = None,
     ) -> None:
         super().__init__(
@@ -223,6 +235,7 @@ class Perceptron(GrowingMLP):
             number_hidden_layers=1,
             activation=activation,
             use_bias=use_bias,
+            flatten=flatten,
             device=device,
         )
 

--- a/tests/test_growing_mlp.py
+++ b/tests/test_growing_mlp.py
@@ -77,6 +77,22 @@ class TestGrowingMLP(unittest.TestCase):
         factors = self.model.normalisation_factor(values)
         self.assertEqual(factors.shape, values.shape)
 
+    def test_without_flatten(self):
+        # Test the model without flattening the input
+        in_features = (10, 4)
+        model = GrowingMLP(
+            in_features=in_features,
+            out_features=self.out_features,
+            hidden_size=self.hidden_size,
+            number_hidden_layers=self.number_hidden_layers,
+            activation=nn.ReLU(),
+            flatten=False
+        )
+        print(model)
+        x = torch.randn(1, *in_features)
+        y = model.forward(x)
+        self.assertEqual(y.shape, (1, *in_features[:-1], self.out_features))
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Makes flattening optional in GrowingMLP class.
This is needed for Transformer architecture.
Default value makes it compatible with existing code.