### PR TITLE
Fix: fixing statistics normalization for LinearGrowingModule.

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -20,6 +20,7 @@ Develop branch
 Enhancements
 ~~~~~~~~~~~~
 
+- Fix statistics normalization in `LinearGrowingModule` (:gh:`110` by `Stéphane Rivaud`_)
 - Add `GrowingBatchNorm1d` and `GrowingBatchNorm2d` modules to support batch normalization in growing networks (:gh:`101` by `Théo Rudkiewicz`_).
 - Optimize RestrictedConv2dGrowingModule to fasten the simulation of the side effect of a convolution (:gh:`99` by `Théo Rudkiewicz`_).
 - Split Conv2dGrowingModule into two subclass `FullConv2dGrowingModule`(that does the same as the previous class) and  `RestrictedConv2dGrowingModule` (that compute only the best 1x1 convolution as the second layer at growth time) (:gh:`92` by `Théo Rudkiewicz`_).

--- a/src/gromo/modules/linear_growing_module.py
+++ b/src/gromo/modules/linear_growing_module.py
@@ -439,7 +439,7 @@ class LinearGrowingModule(GrowingModule):
                 torch.flatten(input_extended, 0, -2),
                 torch.flatten(input_extended, 0, -2),
             ),
-            torch.tensor(self.input.shape[:-1]).prod().int().item(),
+            self.input.shape[0],
         )
 
     def compute_m_update(
@@ -471,7 +471,7 @@ class LinearGrowingModule(GrowingModule):
                 torch.flatten(self.input_extended, 0, -2),
                 torch.flatten(desired_activation, 0, -2),
             ),
-            torch.tensor(self.input.shape[:-1]).prod().int().item(),
+            self.input.shape[0],
         )
 
     def compute_m_prev_update(
@@ -505,7 +505,7 @@ class LinearGrowingModule(GrowingModule):
                     torch.flatten(self.previous_module.input_extended, 0, -2),
                     torch.flatten(desired_activation, 0, -2),
                 ),
-                torch.tensor(self.input.shape[:-1]).prod().int().item(),
+                self.input.shape[0],
             )
         elif isinstance(self.previous_module, LinearMergeGrowingModule):
             if self.previous_module.number_of_successors > 1:
@@ -546,7 +546,7 @@ class LinearGrowingModule(GrowingModule):
                     torch.flatten(self.previous_module.input_extended, 0, -2),
                     torch.flatten(self.input_extended, 0, -2),
                 ),
-                torch.tensor(self.input.shape[:-1]).prod().int().item(),
+                self.input.shape[0],
             )
         elif isinstance(self.previous_module, LinearMergeGrowingModule):
             return (
@@ -563,30 +563,30 @@ class LinearGrowingModule(GrowingModule):
                 f"for {type(self.previous_module)} as previous module."
             )
 
-    def compute_n_update(self) -> tuple[torch.Tensor, int]:
-        """
-        Compute the update of the tensor N.
-        With the input tensor X and V[+1] the projected desired update at the next layer
-        (V[+1] = dL/dA[+1] - dW[+1]* B), the update is U^{j k} = X^{i j} V[+1]^{i k}.
+    # def compute_n_update(self) -> tuple[torch.Tensor, int]:
+    #     """
+    #     Compute the update of the tensor N.
+    #     With the input tensor X and V[+1] the projected desired update at the next layer
+    #     (V[+1] = dL/dA[+1] - dW[+1]* B), the update is U^{j k} = X^{i j} V[+1]^{i k}.
 
-        Returns
-        -------
-        torch.Tensor
-            update of the tensor N
-        int
-            number of samples used to compute the update
-        """
-        if isinstance(self.next_module, LinearGrowingModule):
-            return (
-                torch.einsum(
-                    "ij,ik->jk",
-                    torch.flatten(self.input, 0, -2),
-                    torch.flatten(self.next_module.projected_desired_update(), 0, -2),
-                ),
-                torch.tensor(self.input.shape[:-1]).prod().int().item(),
-            )
-        else:
-            raise TypeError("The next module must be a LinearGrowingModule.")
+    #     Returns
+    #     -------
+    #     torch.Tensor
+    #         update of the tensor N
+    #     int
+    #         number of samples used to compute the update
+    #     """
+    #     if isinstance(self.next_module, LinearGrowingModule):
+    #         return (
+    #             torch.einsum(
+    #                 "ij,ik->jk",
+    #                 torch.flatten(self.input, 0, -2),
+    #                 torch.flatten(self.next_module.projected_desired_update(), 0, -2),
+    #             ),
+    #             self.input.shape[0],
+    #         )
+    #     else:
+    #         raise TypeError("The next module must be a LinearGrowingModule.")
 
     @property
     def tensor_s_growth(self):


### PR DESCRIPTION
Statistics are only normalized by the bactch size when input has more than 2 dimensions, e.g. (batch, *, *, dim).