### PR TITLE
!fix(GrowingModule._auxiliary_compute_alpha_omega): Fix a sign error

### DIFF
--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -1377,7 +1377,7 @@ class GrowingModule(torch.nn.Module):
         if use_projected_gradient:
             matrix_n = self.tensor_n
         else:
-            matrix_n = self.tensor_m_prev()
+            matrix_n = -self.tensor_m_prev()
         # It seems that sometimes the tensor N is not accessible.
         # I have no idea why this occurs sometimes.
 


### PR DESCRIPTION
Swith the sign of `matrix_n` in the case where `use_projected_gradient` is False. Indeed when we use `tensor_n` the sign is already corrected (see `def tensor_n`), it was not corrected yet when we use `tensor_m_prev`.