### PR TITLE
ref: Moved `safe_forward` to  `utils.py`

### DIFF
--- a/src/gromo/containers/growing_container.py
+++ b/src/gromo/containers/growing_container.py
@@ -2,31 +2,7 @@ import torch
 
 from gromo.config.loader import load_config
 from gromo.modules.growing_module import GrowingModule, MergeGrowingModule
-from gromo.utils.utils import get_correct_device, global_device
-
-
-def safe_forward(self, input: torch.Tensor) -> torch.Tensor:
-    """Safe Linear forward function for empty input tensors
-    Resolves bug with shape transformation when using cuda
-
-    Parameters
-    ----------
-    input : torch.Tensor
-        input tensor
-
-    Returns
-    -------
-    torch.Tensor
-        F.linear forward function output
-    """
-    assert (
-        input.shape[-1] == self.in_features
-    ), f"Input shape {input.shape} must match the input feature size. Expected: {self.in_features}, Found: {input.shape[1]}"
-    if self.in_features == 0:
-        return torch.zeros(
-            input.shape[0], self.out_features, device=global_device(), requires_grad=True
-        )  # TODO: change to self.device?
-    return torch.nn.functional.linear(input, self.weight, self.bias)
+from gromo.utils.utils import get_correct_device
 
 
 class GrowingContainer(torch.nn.Module):

--- a/src/gromo/containers/growing_dag.py
+++ b/src/gromo/containers/growing_dag.py
@@ -7,13 +7,13 @@ import networkx as nx
 import torch
 import torch.nn as nn
 
-from gromo.containers.growing_container import GrowingContainer, safe_forward
+from gromo.containers.growing_container import GrowingContainer
 from gromo.modules.constant_module import ConstantModule
 from gromo.modules.linear_growing_module import (
     LinearGrowingModule,
     LinearMergeGrowingModule,
 )
-from gromo.utils.utils import activation_fn, f1_micro
+from gromo.utils.utils import activation_fn, f1_micro, safe_forward
 
 
 supported_layer_types = ["linear", "convolution"]

--- a/src/gromo/utils/utils.py
+++ b/src/gromo/utils/utils.py
@@ -101,6 +101,30 @@ def torch_ones(*size: tuple[int, int], **kwargs) -> torch.Tensor:
         return torch.ones(*size, device=__global_device, **kwargs)
 
 
+def safe_forward(self, input: torch.Tensor) -> torch.Tensor:
+    """Safe Linear forward function for empty input tensors
+    Resolves bug with shape transformation when using cuda
+
+    Parameters
+    ----------
+    input : torch.Tensor
+        input tensor
+
+    Returns
+    -------
+    torch.Tensor
+        F.linear forward function output
+    """
+    assert (
+        input.shape[-1] == self.in_features
+    ), f"Input shape {input.shape} must match the input feature size. Expected: {self.in_features}, Found: {input.shape[1]}"
+    if self.in_features == 0:
+        return torch.zeros(
+            input.shape[0], self.out_features, device=global_device(), requires_grad=True
+        )  # TODO: change to self.device?
+    return torch.nn.functional.linear(input, self.weight, self.bias)
+
+
 def set_from_conf(self, name: str, default: Any = None, setter: bool = True) -> Any:
     """Standardize private argument setting from config file
 

--- a/src/gromo/utils/utils.py
+++ b/src/gromo/utils/utils.py
@@ -117,7 +117,7 @@ def safe_forward(self, input: torch.Tensor) -> torch.Tensor:
     """
     assert (
         input.shape[-1] == self.in_features
-    ), f"Input shape {input.shape} must match the input feature size. Expected: {self.in_features}, Found: {input.shape[1]}"
+    ), f"Input shape {input.shape} must match the input feature size. Expected: {self.in_features}, Found: {input.shape[-1]}"
     if self.in_features == 0:
         return torch.zeros(
             input.shape[0], self.out_features, device=global_device(), requires_grad=True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -376,14 +376,11 @@ class TestUtils(TorchTestCase):
 
                 # Test with zero input features (edge case)
                 zero_in_features = 0
-                zero_out_features = 3
-                zero_linear = nn.Linear(
-                    zero_in_features, zero_out_features, device=device
-                )
+                zero_linear = nn.Linear(zero_in_features, out_features, device=device)
                 zero_input = torch.empty(batch_size, zero_in_features, device=device)
 
                 zero_output = safe_forward(zero_linear, zero_input)
-                self.assertShapeEqual(zero_output, (batch_size, zero_out_features))
+                self.assertShapeEqual(zero_output, (batch_size, out_features))
                 # Should return zeros with requires_grad=True
                 self.assertTrue(torch.all(zero_output == 0))
                 self.assertTrue(zero_output.requires_grad)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import random
-import unittest
 from unittest.mock import MagicMock, patch
 
 import torch
@@ -17,14 +16,16 @@ from gromo.utils.utils import (
     line_search,
     mini_batch_gradient_descent,
     reset_device,
+    safe_forward,
     set_device,
     set_from_conf,
     torch_ones,
     torch_zeros,
 )
+from tests.torch_unittest import TorchTestCase
 
 
-class TestUtils(unittest.TestCase):
+class TestUtils(TorchTestCase):
     @classmethod
     def setUpClass(cls):
         """Set up available devices for testing"""
@@ -346,6 +347,78 @@ class TestUtils(unittest.TestCase):
         self.assertGreater(f1_macro_score, 0.0)
         self.assertLess(f1_macro_score, 1.0)
 
+    def test_safe_forward(self) -> None:
+        """Test safe_forward function for Linear layers with various input configurations."""
+        # Test on each available device
+        for device_name in self.available_devices:
+            with self.subTest(device=device_name):
+                set_device(device_name)
+                device = global_device()
+
+                # Test normal case with non-zero features
+                in_features = 5
+                out_features = 3
+                batch_size = 4
+
+                # Create a mock linear layer
+                linear_layer = nn.Linear(in_features, out_features, device=device)
+
+                # Test normal forward pass
+                input_tensor = torch.randn(batch_size, in_features, device=device)
+                output = safe_forward(linear_layer, input_tensor)
+
+                self.assertShapeEqual(output, (batch_size, out_features))
+                # Compare with normal linear forward
+                expected_output = torch.nn.functional.linear(
+                    input_tensor, linear_layer.weight, linear_layer.bias
+                )
+                self.assertAllClose(output, expected_output)
+
+                # Test with zero input features (edge case)
+                zero_in_features = 0
+                zero_out_features = 3
+                zero_linear = nn.Linear(
+                    zero_in_features, zero_out_features, device=device
+                )
+                zero_input = torch.empty(batch_size, zero_in_features, device=device)
+
+                zero_output = safe_forward(zero_linear, zero_input)
+                self.assertShapeEqual(zero_output, (batch_size, zero_out_features))
+                # Should return zeros with requires_grad=True
+                self.assertTrue(torch.all(zero_output == 0))
+                self.assertTrue(zero_output.requires_grad)
+
+                # Test input shape mismatch (should raise AssertionError)
+                wrong_input = torch.randn(batch_size, in_features + 1, device=device)
+                with self.assertRaises(AssertionError) as context:
+                    safe_forward(linear_layer, wrong_input)
+
+                self.assertIn("Input shape", str(context.exception))
+                self.assertIn("must match the input feature size", str(context.exception))
+
+                # Test with different batch dimensions
+                input_3d = torch.randn(2, 3, in_features, device=device)
+                output_3d = safe_forward(linear_layer, input_3d)
+                self.assertShapeEqual(output_3d, (2, 3, out_features))
+
+                # Test with single sample
+                input_single = torch.randn(1, in_features, device=device)
+                output_single = safe_forward(linear_layer, input_single)
+                self.assertShapeEqual(output_single, (1, out_features))
+
+                # Test without bias
+                linear_no_bias = nn.Linear(
+                    in_features, out_features, bias=False, device=device
+                )
+                output_no_bias = safe_forward(linear_no_bias, input_tensor)
+                self.assertShapeEqual(output_no_bias, (batch_size, out_features))
+                expected_no_bias = torch.nn.functional.linear(
+                    input_tensor, linear_no_bias.weight, None
+                )
+                self.assertAllClose(output_no_bias, expected_no_bias)
+
 
 if __name__ == "__main__":
-    unittest.main()
+    from unittest import main
+
+    main()


### PR DESCRIPTION
This location is more logical for  `safe_forward`.
This fix #124.

In addition i changed the error message in the assert changing `Found: {input.shape[1]}` by `Found: {input.shape[-1]}`. This seems more logical @stelladk can you confirm this is ok for you ?