### PR TITLE
fix(RestrictedConv2dGrowingModule.bordered_unfolded_extended_prev_input): Use the correct input size to compute the border effect of the convolution.

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -20,6 +20,7 @@ Develop branch
 Enhancements
 ~~~~~~~~~~~~
 
+- fix(RestrictedConv2dGrowingModule.bordered_unfolded_extended_prev_input): Use the correct input size to compute the border effect of the convolution. (:gh:`147` by `Théo Rudkiewicz`_)
 - Create a `input_size` property in GrowingModule. (:gh:`143` by `Théo Rudkiewicz`_)
 - Improve `GrowingContainer` to allow `GrowingContainer` as submodules (:gh:`133` by `Théo Rudkiewicz`_ and `Stella Douka`_).
 - Fix sign errors in `compute_optimal_added_parameters` when using `tensor_m_prev` and in `tensor_n` computation. Add unit tests to cover these cases (:gh:`118` and :gh:`115` by `Théo Rudkiewicz`_).

--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -660,10 +660,13 @@ class RestrictedConv2dGrowingModule(Conv2dGrowingModule):
                 raise NotImplementedError
             else:
                 raise NotImplementedError
-        self.previous_module.update_input_size()
+        input_size = self.update_input_size(compute_from_previous=True)
+        assert (
+            input_size is not None
+        ), f"The input size should be known to compute the bordered unfolded input for {self.name}."
         return apply_border_effect_on_unfolded(
             unfolded_tensor=self.previous_module.unfolded_extended_input,
-            original_size=self.input_size,
+            original_size=input_size,
             border_effect_conv=self.layer,
             identity_conv=self.bordering_convolution,
         )

--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -663,7 +663,7 @@ class RestrictedConv2dGrowingModule(Conv2dGrowingModule):
         self.previous_module.update_input_size()
         return apply_border_effect_on_unfolded(
             unfolded_tensor=self.previous_module.unfolded_extended_input,
-            original_size=self.previous_module.input_size,
+            original_size=self.input_size,
             border_effect_conv=self.layer,
             identity_conv=self.bordering_convolution,
         )

--- a/src/gromo/utils/tools.py
+++ b/src/gromo/utils/tools.py
@@ -400,6 +400,9 @@ def apply_border_effect_on_unfolded(
     assert isinstance(border_effect_conv, torch.nn.Conv2d) or isinstance(
         identity_conv, torch.nn.Conv2d
     ), "Either 'border_effect_conv' or 'identity_conv' must be provided."
+    assert all(
+        isinstance(s, int) and s > 0 for s in original_size
+    ), "'original_size' must be a tuple of positive integers."
 
     if identity_conv is None:
         assert isinstance(

--- a/tests/test_conv2d_growing_module.py
+++ b/tests/test_conv2d_growing_module.py
@@ -49,6 +49,7 @@ class TestConv2dGrowingModule(TorchTestCase):
                 padding=1,
                 use_bias=bias,
                 device=global_device(),
+                name="first_layer",
             )
             demo_out = self._tested_class(
                 in_channels=5,
@@ -57,6 +58,7 @@ class TestConv2dGrowingModule(TorchTestCase):
                 use_bias=bias,
                 previous_module=demo_in,
                 device=global_device(),
+                name="second_layer",
             )
             self.demo_couple[bias] = (demo_in, demo_out)
 
@@ -442,7 +444,6 @@ class TestFullConv2dGrowingModule(TestConv2dGrowingModule):
             False
         ]  # Use without bias for simplicity
 
-        net = torch.nn.Sequential(demo_layer_1, demo_layer_2)
         demo_layer_2.store_pre_activity = True
         demo_layer_1.store_input = True
         demo_layer_2.tensor_m_prev.init()
@@ -536,7 +537,6 @@ class TestFullConv2dGrowingModule(TestConv2dGrowingModule):
                 loss = torch.norm(y)
                 loss.backward()
 
-                demo_couple[0].update_input_size()
                 demo_couple[1].update_input_size(compute_from_previous=True)
                 demo_couple[1].tensor_m_prev.update()
 
@@ -1034,7 +1034,6 @@ class TestRestrictedConv2dGrowingModule(TestConv2dGrowingModule):
         loss = torch.nn.functional.mse_loss(y, torch.zeros_like(y))
         loss.backward()
 
-        demo_in.update_input_size()
         demo_out.tensor_m_prev.update()
 
         s0 = demo_in.in_channels * demo_in.kernel_size[0] * demo_in.kernel_size[1] + (
@@ -1214,8 +1213,6 @@ class TestRestrictedConv2dGrowingModule(TestConv2dGrowingModule):
         output = current_module(intermediate)
 
         # Update input sizes
-        current_module.update_input_size(compute_from_previous=True)
-
         # Access bordered_unfolded_extended_prev_input - this should not crash
         bordered_tensor = current_module.bordered_unfolded_extended_prev_input
 

--- a/tests/test_conv2d_growing_module.py
+++ b/tests/test_conv2d_growing_module.py
@@ -1174,6 +1174,63 @@ class TestRestrictedConv2dGrowingModule(TestConv2dGrowingModule):
         else:
             self.assertIsNone(alpha_b)
 
+    def test_bordered_unfolded_extended_prev_input_shape(self):
+        """
+        Test that bordered_unfolded_extended_prev_input runs correctly and returns proper shape.
+
+        This test mimics the setup from minimal_crashing_code_2 to ensure that the
+        bordered_unfolded_extended_prev_input property works correctly and returns
+        a tensor with the expected shape, particularly testing the fix for the
+        border effect bug.
+        """
+        # Create previous module (first conv layer) - mimics minimal_crashing_code_2
+        prev_module = RestrictedConv2dGrowingModule(
+            in_channels=2,
+            out_channels=7,
+            kernel_size=(3, 5),
+            stride=2,
+            padding=1,
+            use_bias=False,
+            input_size=(7, 11),
+        )
+
+        # Create current module (second conv layer)
+        current_module = RestrictedConv2dGrowingModule(
+            in_channels=7,
+            out_channels=11,
+            kernel_size=(5, 3),
+            stride=1,
+            padding=1,
+            use_bias=False,
+            previous_module=prev_module,
+        )
+
+        # Set up input and forward pass
+        x = torch.randn(1, 2, 13, 17, device=global_device())
+        prev_module.store_input = True
+
+        # Forward pass through both modules
+        intermediate = prev_module(x)
+        output = current_module(intermediate)
+
+        # Update input sizes
+        current_module.update_input_size(compute_from_previous=True)
+
+        # Access bordered_unfolded_extended_prev_input - this should not crash
+        bordered_tensor = current_module.bordered_unfolded_extended_prev_input
+
+        # Verify tensor structure
+        self.assertShapeEqual(
+            bordered_tensor,
+            (
+                output.shape[0],  # Batch size
+                prev_module.in_channels
+                * prev_module.kernel_size[0]
+                * prev_module.kernel_size[1],
+                output.shape[2] * output.shape[3],
+            ),
+        )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
If we have two convolution:
$(C[-1], H[-1],W[-1]) \longrightarrow (C, H,W) \longrightarrow (C[+1], W[+1], H[+1])$ the unfolded input is of shape $(C[-1] H_dW_d, HW)$ and should bordered to the shape $(C[-1] H_dW_d, H[+1]W[+1])$. Before it was bordered to  $(C[-1] H_dW_d, HW)$.
This fix #142 : https://github.com/growingnet/gromo/issues/142