### PR TITLE
ci: Add ruff type linting and formating in the CI

### DIFF
--- a/.github/workflows/ruff-check.yml
+++ b/.github/workflows/ruff-check.yml
@@ -34,8 +34,3 @@ jobs:
       - name: Run ruff formatting check
         run: |
           ruff format --check .
-
-      - name: Run ruff with type checking annotations
-        run: |
-          # Check specifically for type annotation issues
-          ruff check --select=ANN,PYI,TCH --output-format=github . || true

--- a/.github/workflows/ruff-check.yml
+++ b/.github/workflows/ruff-check.yml
@@ -1,0 +1,41 @@
+name: Ruff Type Check
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  ruff-check:
+    name: Ruff Type Check
+    runs-on: ubuntu-latest
+    continue-on-error: true  # Makes this check non-blocking
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: |
+          python -m pip install --upgrade pip
+          pip install ruff
+
+      - name: Run ruff linting
+        run: |
+          ruff check --output-format=github .
+
+      - name: Run ruff formatting check
+        run: |
+          ruff format --check .
+
+      - name: Run ruff with type checking annotations
+        run: |
+          # Check specifically for type annotation issues
+          ruff check --select=ANN,PYI,TCH --output-format=github . || true

--- a/.github/workflows/ruff-check.yml
+++ b/.github/workflows/ruff-check.yml
@@ -1,4 +1,4 @@
-name: Ruff Type Check
+name: Ruff Linting
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
   cancel-in-progress: true
@@ -11,7 +11,7 @@ on:
 
 jobs:
   ruff-check:
-    name: Ruff Type Check
+    name: Ruff Linting
     runs-on: ubuntu-latest
     continue-on-error: true  # Makes this check non-blocking
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: ruff-check,ruff-format
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: pre-commit/action@v3.0.1
         env:
-          SKIP: ruff-check,ruff-format
+          SKIP: ruff-check  # ,ruff-format
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,9 +58,7 @@ repos:
       rev: v0.12.2
       hooks:
       -   id: ruff-check
-          args: ["--fix", "--output-format=full", "--exit-zero"]
-          # --exit-zero to make ruff is non-blocking
-          # it will show warnings but not prevent commits
+          args: ["--fix", "--output-format=full"]
           verbose: true
       # - id: ruff-format conflict with black
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,8 @@ repos:
       rev: v0.12.2
       hooks:
       -   id: ruff-check
-          args: ["--fix", "--output-format=full"]
+          args: ["--fix", "--output-format=full", "--exit-zero"]
+          verbose: true
       # - id: ruff-format conflict with black
 
   - repo: https://github.com/codespell-project/codespell

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: '.*svg$|.*ipynb$|.*md$|.*png$|.*odg|.*tex'
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-toml
@@ -21,26 +21,26 @@ repos:
 
 
   - repo: https://github.com/psf/black
-    rev: 24.10.0
+    rev: 25.9.0
     hooks:
       - id: black
         language_version: python3
         args: [ --line-length=90, --target-version=py311, --target-version=py312 ]
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.19.1
+    rev: 1.20.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [ black==23.3.0 ]
         exclude: ^.github/
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.1.0
     hooks:
       - id: isort
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
+    rev: 7.3.0
     hooks:
       - id: flake8
         additional_dependencies: [
@@ -55,7 +55,7 @@ repos:
         exclude: ^docs/ | ^setup\.py$ |
 
   -   repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.12.2
+      rev: v0.13.3
       hooks:
       -   id: ruff-check
           args: ["--fix", "--output-format=full"]
@@ -63,7 +63,7 @@ repos:
       # - id: ruff-format conflict with black
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,6 +59,8 @@ repos:
       hooks:
       -   id: ruff-check
           args: ["--fix", "--output-format=full", "--exit-zero"]
+          # --exit-zero to make ruff is non-blocking
+          # it will show warnings but not prevent commits
           verbose: true
       # - id: ruff-format conflict with black
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
       hooks:
       -   id: ruff-check
           args: ["--fix", "--output-format=full"]
-      -   id: ruff-format
+      # - id: ruff-format conflict with black
 
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,13 @@ repos:
         ]
         exclude: ^docs/ | ^setup\.py$ |
 
+  -   repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.12.2
+      hooks:
+      -   id: ruff-check
+          args: ["--fix", "--output-format=full"]
+      -   id: ruff-format
+
   - repo: https://github.com/codespell-project/codespell
     rev: v2.3.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![codecov](https://codecov.io/github/growingnet/gromo/graph/badge.svg?token=87HWKJ6H6D)](https://codecov.io/github/growingnet/gromo)
 [![Tests](https://github.com/growingnet/gromo/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/growingnet/gromo/actions/workflows/tests.yml)
+[![Ruff Type Check](https://github.com/growingnet/gromo/actions/workflows/ruff-check.yml/badge.svg?branch=main)](https://github.com/growingnet/gromo/actions/workflows/ruff-check.yml)
 
 # GroMo
 

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -20,6 +20,7 @@ Develop branch
 Enhancements
 ~~~~~~~~~~~~
 
+- Add `ruff` linter to pre-commit hooks and to the CI (:gh:`151` by `Théo Rudkiewicz`_)
 - Add `GrowingBlock` to mimic a ResNet 18/34 block. (:gh:`106` by `Théo Rudkiewicz`_)
 - fix(RestrictedConv2dGrowingModule.bordered_unfolded_extended_prev_input): Use the correct input size to compute the border effect of the convolution. (:gh:`147` by `Théo Rudkiewicz`_)
 - Create a `input_size` property in GrowingModule. (:gh:`143` by `Théo Rudkiewicz`_)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,21 +97,29 @@ target-version = "py311"
 [tool.ruff.lint]
 # Enable basic linting rules with type-related checks
 select = [
-    "F",    # Pyflakes
-    "E",    # pycodestyle errors
-    "W",    # pycodestyle warnings
-    "I",    # isort
-    "N",    # pep8-naming
-    "UP",   # pyupgrade
-    "ANN",  # flake8-annotations (basic type checking)
-    "B",    # flake8-bugbear
-    "A",    # flake8-builtins
-    "COM",  # flake8-commas
-    "C4",   # flake8-comprehensions
-    "PYI",  # flake8-pyi (stub files)
-    "TCH",  # flake8-type-checking
-    "ARG",  # flake8-unused-arguments
-    "RUF",  # Ruff-specific rules
+    # "ERA", # no commented code
+    # "ANN", # flake8-annotations (basic type checking)
+    "BLE",   # blind except
+    # "B",   # flake8-bugbear
+    "A",     # flake8-builtins
+    "COM",   # flake8-commas
+    "C4",    # flake8-comprehensions
+    # "EM",  # flake8-errmsg
+    "FA",    # flake8-future-annotations
+    "ICN",   # flake8-import-conventions
+    "PIE",   # flake8-pie
+    "PYI",   # flake8-pyi (stub files)
+    "F",     # Pyflakes
+    "SIM",   # flake8-simplify
+    "TC",    # flake8-type-checking
+    "ARG",   # flake8-unused-arguments
+    "N",     # pep8-naming
+    "E",     # pycodestyle errors
+    "W",     # pycodestyle warnings
+    "I",     # isort
+    "N",     # pep8-naming
+    # "UP",  # pyupgrade
+    "RUF",   # Ruff-specific rules
 ]
 
 # Ignore some rules that might be too strict for existing codebase
@@ -119,6 +127,7 @@ ignore = [
     "ANN401",  # Dynamically typed expressions (Any) are disallowed
     "COM812",  # Trailing comma missing (conflicts with formatter)
     "COM819",  # Trailing comma prohibited (conflicts with formatter)
+    "C408",    # can initialise dict with dict(...)
 ]
 
 [tool.ruff.lint.per-file-ignores]
@@ -133,3 +142,6 @@ ignore = [
 # Use same formatting as black
 quote-style = "double"
 indent-style = "space"
+
+[tool.ruff.lint.isort]
+lines-after-imports = 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 ]
 [project.optional-dependencies]
 test = ["coverage"]
+dev = ["ruff", "pre-commit"]
 doc = [
     "Sphinx",
     "sphinx-gallery",
@@ -88,3 +89,47 @@ exclude_also = [
     # Defensive assertion code
     "raise NotImplementedError",
 ]
+
+[tool.ruff]
+line-length = 90
+target-version = "py311"
+
+[tool.ruff.lint]
+# Enable basic linting rules with type-related checks
+select = [
+    "F",    # Pyflakes
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "I",    # isort
+    "N",    # pep8-naming
+    "UP",   # pyupgrade
+    "ANN",  # flake8-annotations (basic type checking)
+    "B",    # flake8-bugbear
+    "A",    # flake8-builtins
+    "COM",  # flake8-commas
+    "C4",   # flake8-comprehensions
+    "PYI",  # flake8-pyi (stub files)
+    "TCH",  # flake8-type-checking
+    "ARG",  # flake8-unused-arguments
+    "RUF",  # Ruff-specific rules
+]
+
+# Ignore some rules that might be too strict for existing codebase
+ignore = [
+    "ANN401",  # Dynamically typed expressions (Any) are disallowed
+    "COM812",  # Trailing comma missing (conflicts with formatter)
+    "COM819",  # Trailing comma prohibited (conflicts with formatter)
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests can have more relaxed type checking
+"tests/**/*.py" = ["ANN", "ARG"]
+# Examples can ignore type annotations
+"examples/**/*.py" = ["ANN"]
+# Init files can ignore unused imports
+"**/__init__.py" = ["F401"]
+
+[tool.ruff.format]
+# Use same formatting as black
+quote-style = "double"
+indent-style = "space"


### PR DESCRIPTION
I added ruff in the CI pipeline to check the type checking and the formating. It is a non-blocking check.

I also added ruff to the pre-commit. It will change the code so don't hesitate to check what it changed. (Normally it is a classical tool used with similar settings in skleran : https://github.com/scikit-learn/scikit-learn/blob/4ba9a8a3b20e2b1ad94e15a7f10bd3b2ef66517a/.pre-commit-config.yaml#L9 )

I had to change the test CI so that it does not runs the ruff part of the pre-commit otherwise all tests would fail.