### PR TITLE
feat: Include the weight statistics computation

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -20,6 +20,7 @@ Develop branch
 Enhancements
 ~~~~~~~~~~~~
 
+- Add `weights_statistics` method to `GrowingModule` and `GrowingContainer` to retrieve statistics of weights in all growing layers. (:gh:`152` by `Théo Rudkiewicz`_)
 - Add `GrowingBlock` to mimic a ResNet 18/34 block. (:gh:`106` by `Théo Rudkiewicz`_)
 - fix(RestrictedConv2dGrowingModule.bordered_unfolded_extended_prev_input): Use the correct input size to compute the border effect of the convolution. (:gh:`147` by `Théo Rudkiewicz`_)
 - Create a `input_size` property in GrowingModule. (:gh:`143` by `Théo Rudkiewicz`_)

--- a/src/gromo/containers/growing_block.py
+++ b/src/gromo/containers/growing_block.py
@@ -324,14 +324,6 @@ class GrowingBlock(GrowingContainer):
         """
         return self.second_layer.first_order_improvement
 
-    def weights_statistics(self) -> dict[str, dict[str, dict[str, float]]]:
-        """Get the statistics of the weights in the growing layers."""
-        stats = {
-            self.first_layer.name: self.first_layer.weights_statistics(),
-            self.second_layer.name: self.second_layer.weights_statistics(),
-        }
-        return stats
-
 
 class LinearGrowingBlock(GrowingBlock):
     def __init__(

--- a/src/gromo/containers/growing_block.py
+++ b/src/gromo/containers/growing_block.py
@@ -324,6 +324,14 @@ class GrowingBlock(GrowingContainer):
         """
         return self.second_layer.first_order_improvement
 
+    def weights_statistics(self) -> dict[str, dict[str, dict[str, float]]]:
+        """Get the statistics of the weights in the growing layers."""
+        stats = {
+            self.first_layer.name: self.first_layer.weights_statistics(),
+            self.second_layer.name: self.second_layer.weights_statistics(),
+        }
+        return stats
+
 
 class LinearGrowingBlock(GrowingBlock):
     def __init__(

--- a/src/gromo/containers/growing_container.py
+++ b/src/gromo/containers/growing_container.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import torch
 
 from gromo.config.loader import load_config
@@ -144,3 +146,11 @@ class GrowingContainer(torch.nn.Module):
         for layer in self._growing_layers:
             if isinstance(layer, (MergeGrowingModule, GrowingContainer)):
                 layer.update_size()
+
+    def weights_statistics(self) -> dict[str, Any]:
+        """Get the statistics of the weights in the growing layers.
+        Due to the recursive nature of the containers, the returned dictionary
+        contains nested dictionaries for each layer.
+        """
+        stats = {layer.name: layer.weights_statistics() for layer in self._growing_layers}
+        return stats

--- a/src/gromo/containers/growing_container.py
+++ b/src/gromo/containers/growing_container.py
@@ -152,5 +152,8 @@ class GrowingContainer(torch.nn.Module):
         Due to the recursive nature of the containers, the returned dictionary
         contains nested dictionaries for each layer.
         """
-        stats = {layer.name: layer.weights_statistics() for layer in self._growing_layers}
+        stats = {}
+        for module in self.modules():
+            if isinstance(module, GrowingModule):
+                stats[module.name] = module.weights_statistics()
         return stats

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -7,7 +7,7 @@ import torch
 from gromo.config.loader import load_config
 from gromo.utils.tensor_statistic import TensorStatistic
 from gromo.utils.tools import compute_optimal_added_parameters, optimal_delta
-from gromo.utils.utils import get_correct_device
+from gromo.utils.utils import get_correct_device, tensor_statistics
 
 
 class MergeGrowingModule(torch.nn.Module):
@@ -1765,6 +1765,24 @@ class GrowingModule(torch.nn.Module):
                     "module is needed.",
                     UserWarning,
                 )
+
+    def weights_statistics(self) -> dict[str, dict[str, float]]:
+        """
+        Get the statistics of the weights in the growing layer.
+
+        Returns
+        -------
+        dict[str, dict[str, float]]
+            A dictionary where keys are weights names and
+            values are dictionaries of weight statistics.
+        """
+        layer_stats = {
+            "weight": self.tensor_statistics(self.layer.weight),
+        }
+        if self.layer.bias is not None:
+            layer_stats["bias"] = tensor_statistics(self.layer.bias)
+
+        return layer_stats
 
 
 if __name__ == "__main__":

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -7,7 +7,7 @@ import torch
 from gromo.config.loader import load_config
 from gromo.utils.tensor_statistic import TensorStatistic
 from gromo.utils.tools import compute_optimal_added_parameters, optimal_delta
-from gromo.utils.utils import get_correct_device, tensor_statistics
+from gromo.utils.utils import compute_tensor_stats, get_correct_device
 
 
 class MergeGrowingModule(torch.nn.Module):
@@ -1780,7 +1780,7 @@ class GrowingModule(torch.nn.Module):
             "weight": self.tensor_statistics(self.layer.weight),
         }
         if self.layer.bias is not None:
-            layer_stats["bias"] = tensor_statistics(self.layer.bias)
+            layer_stats["bias"] = compute_tensor_stats(self.layer.bias)
 
         return layer_stats
 

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -1777,7 +1777,7 @@ class GrowingModule(torch.nn.Module):
             values are dictionaries of weight statistics.
         """
         layer_stats = {
-            "weight": self.tensor_statistics(self.layer.weight),
+            "weight": compute_tensor_stats(self.layer.weight),
         }
         if self.layer.bias is not None:
             layer_stats["bias"] = compute_tensor_stats(self.layer.bias)

--- a/src/gromo/utils/utils.py
+++ b/src/gromo/utils/utils.py
@@ -205,7 +205,7 @@ def compute_tensor_stats(tensor: torch.Tensor) -> dict[str, float]:
     min_value = tensor.min().item()
     max_value = tensor.max().item()
     mean_value = tensor.mean().item()
-    std_value = tensor.std().item() if tensor.numel() > 1 else -1.0
+    std_value = tensor.std().item() if tensor.numel() > 1 else 0.0
     return {
         "min": min_value,
         "max": max_value,

--- a/src/gromo/utils/utils.py
+++ b/src/gromo/utils/utils.py
@@ -1,8 +1,9 @@
-from typing import Any, Callable, Iterable, Optional
+from typing import Any, Callable, Iterable
 
 import numpy as np
 import torch
 import torch.nn as nn
+import torch.utils.data
 
 
 __global_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -185,6 +186,32 @@ def activation_fn(fn_name: str) -> nn.Module:
         return known_activations[fn_name]
     else:
         raise ValueError(f"Unknown activation function: {fn_name}")
+
+
+def tensor_statistics(tensor: torch.Tensor) -> dict[str, float]:
+    """
+    Compute basic statistics of a tensor (min, max, mean, std).
+
+    Parameters
+    ----------
+    tensor : torch.Tensor
+        The input tensor for which to compute statistics.
+
+    Returns
+    -------
+    dict[str, float]
+        A dictionary containing the computed statistics.
+    """
+    min_value = tensor.min().item()
+    max_value = tensor.max().item()
+    mean_value = tensor.mean().item()
+    std_value = tensor.std().item() if tensor.numel() > 1 else -1
+    return {
+        "min": min_value,
+        "max": max_value,
+        "mean": mean_value,
+        "std": std_value,
+    }
 
 
 def line_search(

--- a/src/gromo/utils/utils.py
+++ b/src/gromo/utils/utils.py
@@ -205,7 +205,7 @@ def compute_tensor_stats(tensor: torch.Tensor) -> dict[str, float]:
     min_value = tensor.min().item()
     max_value = tensor.max().item()
     mean_value = tensor.mean().item()
-    std_value = tensor.std().item() if tensor.numel() > 1 else -1
+    std_value = tensor.std().item() if tensor.numel() > 1 else -1.0
     return {
         "min": min_value,
         "max": max_value,

--- a/src/gromo/utils/utils.py
+++ b/src/gromo/utils/utils.py
@@ -188,7 +188,7 @@ def activation_fn(fn_name: str) -> nn.Module:
         raise ValueError(f"Unknown activation function: {fn_name}")
 
 
-def tensor_statistics(tensor: torch.Tensor) -> dict[str, float]:
+def compute_tensor_stats(tensor: torch.Tensor) -> dict[str, float]:
     """
     Compute basic statistics of a tensor (min, max, mean, std).
 

--- a/tests/test_growing_container.py
+++ b/tests/test_growing_container.py
@@ -33,6 +33,33 @@ def gather_statistics(dataloader, model, loss):
         model.update_computation()
 
 
+# Create a dummy GrowingContainer to test the base class method
+class DummyGrowingContainer(GrowingContainer):
+    def __init__(self, in_features, out_features):
+        super().__init__(in_features=in_features, out_features=out_features)
+        # Add some GrowingModule instances
+        self.layer1 = LinearGrowingModule(
+            in_features=in_features, out_features=4, name="layer1"
+        )
+        self.layer2 = LinearGrowingModule(
+            in_features=4, out_features=out_features, name="layer2"
+        )
+        self.set_growing_layers()
+
+    def set_growing_layers(self):
+        self._growing_layers = [self.layer1, self.layer2]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.layer2(self.layer1(x))
+
+    @property
+    def first_order_improvement(self) -> torch.Tensor:
+        return torch.tensor(0.0)
+
+    def extended_forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.forward(x)
+
+
 class TestGrowingContainer(unittest.TestCase):
     """
     Test the GrowingContainer class. We only test the function calls to
@@ -342,6 +369,21 @@ class TestGrowingContainer(unittest.TestCase):
         self.assertEqual(
             container.merge.previous_tensor_s._shape,
             (assumed_total_in_features, assumed_total_in_features),
+        )
+
+    def test_weights_statistics(self):
+        """Test that weights_statistics method runs and returns a dictionary."""
+
+        # Test the dummy container
+        container = DummyGrowingContainer(
+            in_features=self.in_features, out_features=self.out_features
+        )
+
+        stats = container.weights_statistics()
+
+        # Check that the result is a dictionary
+        self.assertIsInstance(
+            stats, dict, "weights_statistics should return a dictionary"
         )
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from gromo.utils.utils import (
     activation_fn,
     batch_gradient_descent,
     calculate_true_positives,
+    compute_tensor_stats,
     f1,
     f1_macro,
     f1_micro,
@@ -413,6 +414,23 @@ class TestUtils(TorchTestCase):
                     input_tensor, linear_no_bias.weight, None
                 )
                 self.assertAllClose(output_no_bias, expected_no_bias)
+
+    def test_compute_tensor_stats(self) -> None:
+        """Test compute_tensor_stats function returns correct output types."""
+        # Test with normal tensor (multiple elements)
+        for tensor in [torch.randn(3, 4), torch.tensor(5.0)]:
+            stats = compute_tensor_stats(tensor)
+
+            # Check output type and keys
+            self.assertIsInstance(stats, dict)
+            expected_keys = {"min", "max", "mean", "std"}
+            self.assertEqual(set(stats.keys()), expected_keys)
+
+            # Check value types
+            for key, value in stats.items():
+                self.assertIsInstance(
+                    value, float, f"Value for key '{key}' should be float"
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Weight statsistics compuation was previously done at the levl of particular architecture like MLP, now it is directly part of the `GrowingModule` / `GrowingConatiner`. This is especially useful whenwe run scripts that are agnostic to the model used.