### PR TITLE
!fix: Update `GrowingMLP` to the new standard

### DIFF
--- a/src/gromo/containers/growing_mlp.py
+++ b/src/gromo/containers/growing_mlp.py
@@ -46,7 +46,7 @@ class GrowingMLP(GrowingContainer):
             Device to use for computation.
         """
         if isinstance(in_features, int):
-            self.num_features = in_features
+            pass
         elif isinstance(in_features, (list, tuple)):
             if flatten:
                 in_features = int(torch.tensor(in_features).prod().item())

--- a/src/gromo/containers/growing_mlp.py
+++ b/src/gromo/containers/growing_mlp.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional
+from typing import Any
 
 import torch
 from torch import Tensor, nn
@@ -21,7 +21,7 @@ class GrowingMLP(GrowingContainer):
         activation: nn.Module = nn.SELU(),
         use_bias: bool = True,
         flatten: bool = True,
-        device: Optional[torch.device] = None,
+        device: torch.device | None = None,
     ) -> None:
         """
         Initialize the growing MLP.
@@ -45,28 +45,27 @@ class GrowingMLP(GrowingContainer):
         device : Optional[torch.device]
             Device to use for computation.
         """
+        if isinstance(in_features, int):
+            self.num_features = in_features
+        elif isinstance(in_features, (list, tuple)):
+            if flatten:
+                in_features = int(torch.tensor(in_features).prod().item())
+            else:
+                in_features = in_features[-1]
+        else:
+            raise TypeError(
+                f"Expected in_features to be int, list, or tuple, got {type(in_features)}"
+            )
         super().__init__(
             in_features=in_features, out_features=out_features, device=device
         )
-
-        if isinstance(self.in_features, int):
-            self.num_features = self.in_features
-        elif isinstance(self.in_features, (list, tuple)):
-            if flatten:
-                self.num_features = int(torch.tensor(self.in_features).prod().item())
-            else:
-                self.num_features = self.in_features[-1]
-        else:
-            raise TypeError(
-                f"Expected in_features to be int, list, or tuple, got {type(self.in_features)}"
-            )
 
         # Flatten input
         self.flatten = nn.Flatten(start_dim=1) if flatten else nn.Identity()
         self.layers = nn.ModuleList()
         self.layers.append(
             LinearGrowingModule(
-                self.num_features,
+                self.in_features,
                 hidden_size,
                 post_layer_function=activation,
                 use_bias=use_bias,
@@ -80,7 +79,7 @@ class GrowingMLP(GrowingContainer):
                     hidden_size,
                     hidden_size,
                     post_layer_function=activation,
-                    previous_module=self.layers[-1],
+                    previous_module=self.layers[-1],  # type: ignore
                     use_bias=use_bias,
                     name=f"Layer {i + 1}",
                     device=self.device,
@@ -90,7 +89,7 @@ class GrowingMLP(GrowingContainer):
             LinearGrowingModule(
                 hidden_size,
                 self.out_features,
-                previous_module=self.layers[-1],
+                previous_module=self.layers[-1],  # type: ignore
                 use_bias=use_bias,
                 name=f"Layer {number_hidden_layers}",
                 device=self.device,
@@ -99,8 +98,11 @@ class GrowingMLP(GrowingContainer):
 
         self.set_growing_layers()
 
-    def set_growing_layers(self) -> None:
-        self._growing_layers = list(self.layers[1:])
+    def set_growing_layers(self, index: int | None = None) -> None:
+        if index is not None:
+            self._growing_layers = [self.layers[index]]  # type: ignore
+        else:
+            self._growing_layers = list(self.layers[1:])  # type: ignore
 
     def forward(self, x: Tensor) -> Tensor:
         """
@@ -121,7 +123,7 @@ class GrowingMLP(GrowingContainer):
             x = layer(x)
         return x
 
-    def extended_forward(self, x: Tensor) -> Tensor:
+    def extended_forward(self, x: Tensor) -> Tensor:  # type: ignore
         """
         Forward pass of the growing MLP with the current modifications.
 
@@ -141,32 +143,7 @@ class GrowingMLP(GrowingContainer):
             x, x_ext = layer.extended_forward(x, x_ext)
         return x
 
-    @staticmethod
-    def tensor_statistics(tensor: Tensor) -> Dict[str, float]:
-        min_value = tensor.min().item()
-        max_value = tensor.max().item()
-        mean_value = tensor.mean().item()
-        std_value = tensor.std().item() if tensor.numel() > 1 else -1
-        return {
-            "min": min_value,
-            "max": max_value,
-            "mean": mean_value,
-            "std": std_value,
-        }
-
-    def weights_statistics(self) -> Dict[int, Dict[str, Any]]:
-        statistics = {}
-        for i, layer in enumerate(self.layers):
-            statistics[i] = {
-                "weight": self.tensor_statistics(layer.weight),
-            }
-            if layer.bias is not None:
-                statistics[i]["bias"] = self.tensor_statistics(layer.bias)
-            statistics[i]["input_shape"] = layer.in_features
-            statistics[i]["output_shape"] = layer.out_features
-        return statistics
-
-    def update_information(self) -> Dict[str, Any]:
+    def update_information(self) -> dict[str, Any]:
         information = {}
         for i, layer in enumerate(self._growing_layers):
             layer_information = {
@@ -219,7 +196,7 @@ class GrowingMLP(GrowingContainer):
         assert (
             0 <= item < len(self.layers)
         ), f"{item=} should be in [0, {len(self.layers)})"
-        return self.layers[item]
+        return self.layers[item]  # type: ignore
 
 
 class Perceptron(GrowingMLP):
@@ -231,7 +208,7 @@ class Perceptron(GrowingMLP):
         activation: nn.Module = nn.Sigmoid(),
         use_bias: bool = True,
         flatten: bool = True,
-        device: Optional[torch.device] = None,
+        device: torch.device | None = None,
     ) -> None:
         super().__init__(
             in_features=in_features,

--- a/src/gromo/containers/growing_mlp.py
+++ b/src/gromo/containers/growing_mlp.py
@@ -42,7 +42,7 @@ class GrowingMLP(GrowingContainer):
             Whether to use bias in layers.
         flatten : bool
             Whether to flatten the input before passing it through the network.
-        device : Optional[torch.device]
+        device : torch.device | None
             Device to use for computation.
         """
         if isinstance(in_features, int):

--- a/tests/test_growing_mlp.py
+++ b/tests/test_growing_mlp.py
@@ -65,6 +65,17 @@ class TestGrowingMLP(TorchTestCase):
         gather_statistics(self.dataloader, self.model, self.loss)
         self.model.compute_optimal_updates()
 
+    def test_set_growing_layers(self):
+        """Test setting growing layers in the GrowingMLP model."""
+        # Initially, all layers should be growing
+        self.assertEqual(len(self.model._growing_layers), self.number_hidden_layers)
+        # Set only the first layer to be growing
+        self.model.set_growing_layers(0)
+        self.assertEqual(len(self.model._growing_layers), 1)
+        # Set all layers to be growing again
+        self.model.set_growing_layers()
+        self.assertEqual(len(self.model._growing_layers), self.number_hidden_layers)
+
     def test_forward(self):
         """Test the forward pass of the GrowingMLP model."""
         x = torch.randn(1, self.in_features)

--- a/tests/test_growing_mlp.py
+++ b/tests/test_growing_mlp.py
@@ -77,22 +77,6 @@ class TestGrowingMLP(TorchTestCase):
         y = self.model.extended_forward(x)
         self.assertShapeEqual(y, (1, self.out_features))
 
-    def test_tensor_statistics(self):
-        """Test computation of tensor statistics (min, max, mean, std)."""
-        tensor = torch.randn(10)
-        stats = self.model.tensor_statistics(tensor)
-
-        # Check that all required statistics are present
-        self.assertIn("min", stats)
-        self.assertIn("max", stats)
-        self.assertIn("mean", stats)
-        self.assertIn("std", stats)
-
-        # Test edge case with single element tensor (std should be -1)
-        single_tensor = torch.tensor([5.0])
-        single_stats = self.model.tensor_statistics(single_tensor)
-        self.assertEqual(single_stats["std"], -1)
-
     def test_weights_statistics(self):
         """Test computation of weight statistics for all layers."""
         stats = self.model.weights_statistics()
@@ -100,10 +84,8 @@ class TestGrowingMLP(TorchTestCase):
         self.assertGreater(len(stats), 0)
 
         # Check that each layer has the required statistics
-        for layer_idx, layer_stats in stats.items():
+        for _, layer_stats in stats.items():
             self.assertIn("weight", layer_stats)
-            self.assertIn("input_shape", layer_stats)
-            self.assertIn("output_shape", layer_stats)
             # Note: bias might or might not be present depending on use_bias
 
     def test_weights_statistics_without_bias(self):
@@ -122,7 +104,7 @@ class TestGrowingMLP(TorchTestCase):
         self.assertIsInstance(stats, dict)
 
         # Check that bias is not present in statistics
-        for layer_idx, layer_stats in stats.items():
+        for _, layer_stats in stats.items():
             self.assertNotIn("bias", layer_stats)
 
     def test_update_information(self):
@@ -195,7 +177,7 @@ class TestGrowingMLP(TorchTestCase):
         # Test the TypeError branch for invalid in_features type
         with self.assertRaises(TypeError) as context:
             # Use a type that's not int, list, or tuple to trigger the error
-            invalid_features = set([1, 2, 3])  # set is not supported
+            invalid_features = {1, 2, 3}  # set is not supported
             GrowingMLP(
                 in_features=invalid_features,  # type: ignore  # This should trigger TypeError
                 out_features=self.out_features,
@@ -267,7 +249,7 @@ class TestGrowingMLP(TorchTestCase):
 
         # Test that the model correctly computes num_features as product
         expected_num_features = 2 * 3 * 4
-        self.assertEqual(model.num_features, expected_num_features)
+        self.assertEqual(model.in_features, expected_num_features)
 
         # Test forward pass
         x = torch.randn(1, *in_features)

--- a/tests/test_growing_mlp.py
+++ b/tests/test_growing_mlp.py
@@ -69,8 +69,11 @@ class TestGrowingMLP(TorchTestCase):
         """Test setting growing layers in the GrowingMLP model."""
         # Initially, all layers should be growing
         self.assertEqual(len(self.model._growing_layers), self.number_hidden_layers)
-        # Set only the first layer to be growing
-        self.model.set_growing_layers(0)
+        # Set only the second layer to be growing
+        self.model.set_growing_layers(1)
+        self.assertEqual(len(self.model._growing_layers), 1)
+        # Set only the third layer to be growing
+        self.model.set_growing_layers(2)
         self.assertEqual(len(self.model._growing_layers), 1)
         # Set all layers to be growing again
         self.model.set_growing_layers()


### PR DESCRIPTION
Use new type hinting convention.
Remove redundant methods `tensor_statistics`and `weights_statistics` that are integrated in `GrowingContainer`.
Add an option to choose a specific layer to grow in `set_growing_layers`.


Breaking Changes:

- Statistics computation: Standard deviation of singleton tensors changed from -1 to 0
- Layer stats: Removed input_shape and output_shape attributes
- Changed self.num_features → self.in_features for GrowingContainer compatibility
- Removed test_tensor_statistics (functionality covered by TestUtils.test_compute_tensor_stats)