### PR TITLE
!fix(GrowingBlock): Made it compatible with recent changes

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -20,6 +20,7 @@ Develop branch
 Enhancements
 ~~~~~~~~~~~~
 
+- Update `GrowingBlock` to include recently added features in `GrowingModule` such as `in_neurons` property, `target_in_neurons` parameter, and methods for multi-step growth processes (:gh:`186` by `Théo Rudkiewicz`_)
 - Add `in_neurons` property and `target_in_neurons` parameter to `GrowingModule`, `LinearGrowingModule`, and `Conv2dGrowingModule` for tracking neuron counts during growth. Add `missing_neurons`, `number_of_neurons_to_add`, and `complete_growth` methods to simplify multi-step growth processes (:gh:`187` by `Théo Rudkiewicz`_)
 - Add new normalization methods (:gh:`185` by `Théo Rudkiewicz`_)
 - Update `output_volume` in `Conv2dMergeGrowingModule` based on post_merge_function and reshaping (:gh:`177` by `Stella Douka`_)

--- a/src/gromo/containers/growing_block.py
+++ b/src/gromo/containers/growing_block.py
@@ -302,20 +302,6 @@ class GrowingBlock(GrowingContainer):
         self.second_layer.cross_covariance.reset()
         self.second_layer.tensor_s_growth.reset()
 
-    @property
-    def optimal_delta_layer(self) -> torch.nn.Module | None:
-        """
-        Get the optimal delta layer of the block.
-        """
-        return self.second_layer.optimal_delta_layer
-
-    @optimal_delta_layer.setter
-    def optimal_delta_layer(self, value: torch.nn.Module | None):
-        """
-        Set the optimal delta layer of the block.
-        """
-        self.second_layer.optimal_delta_layer = value
-
     def delete_update(self, **kwargs):
         """
         Delete the update of the block.

--- a/src/gromo/containers/growing_block.py
+++ b/src/gromo/containers/growing_block.py
@@ -449,6 +449,48 @@ class GrowingBlock(GrowingContainer):
         """
         self.second_layer.normalize_optimal_updates(**kwargs)
 
+    def missing_neurons(self) -> int:
+        """
+        Get the number of missing neurons to reach the target hidden features.
+
+        Returns
+        -------
+        int
+            number of missing neurons
+        """
+        return self.second_layer.missing_neurons()
+
+    def number_of_neurons_to_add(
+        self,
+        **kwargs,
+    ) -> int:
+        """Get the number of neurons to add in the next growth step.
+
+        Parameters
+        ----------
+        method : str
+            Method to use for determining the number of neurons to add.
+            Options are "fixed_proportional".
+        number_of_growth_steps : int
+            Number of growth steps planned, used only if method is "proportional".
+
+        Returns
+        -------
+        int
+            Number of neurons to add.
+        """
+        return self.second_layer.number_of_neurons_to_add(**kwargs)
+
+    def complete_growth(self, **kwargs) -> None:
+        """Complete the growth procedure for the block.
+
+        Parameters
+        ----------
+        extension_kwargs : dict
+            Keyword arguments for the extension procedure.
+        """
+        self.second_layer.complete_growth(**kwargs)
+
 
 class LinearGrowingBlock(GrowingBlock):
     def __init__(
@@ -456,6 +498,7 @@ class LinearGrowingBlock(GrowingBlock):
         in_features: int,
         out_features: int,
         hidden_features: int = 0,
+        target_hidden_features: int | None = None,
         activation: torch.nn.Module | None = torch.nn.Identity(),
         pre_activation: torch.nn.Module | None = None,
         mid_activation: torch.nn.Module | None = None,
@@ -524,6 +567,7 @@ class LinearGrowingBlock(GrowingBlock):
             in_features=hidden_features,
             out_features=out_features,
             name=f"{name}(second_layer)",
+            target_in_features=target_hidden_features,
             previous_module=first_layer,
             **kwargs_second_layer,
         )
@@ -554,6 +598,7 @@ class RestrictedConv2dGrowingBlock(GrowingBlock):
         out_channels: int,
         kernel_size: int | tuple[int, int] | None = None,
         hidden_channels: int = 0,
+        target_hidden_channels: int | None = None,
         activation: torch.nn.Module | None = None,
         pre_activation: torch.nn.Module | None = None,
         mid_activation: torch.nn.Module | None = None,
@@ -634,6 +679,7 @@ class RestrictedConv2dGrowingBlock(GrowingBlock):
             in_channels=hidden_channels,
             out_channels=out_channels,
             name=f"{name}(second_layer)",
+            target_in_channels=target_hidden_channels,
             previous_module=first_layer,
             device=device,
             **kwargs_second_layer,

--- a/src/gromo/containers/growing_block.py
+++ b/src/gromo/containers/growing_block.py
@@ -206,7 +206,7 @@ class GrowingBlock(GrowingContainer):
     def extended_forward(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         x: torch.Tensor,
-        mask: None = None,  # noqa: ARG002
+        mask: dict = {},  # noqa: ARG002
     ) -> torch.Tensor:
         """
         Forward pass of the block with the current modifications.

--- a/src/gromo/containers/growing_block.py
+++ b/src/gromo/containers/growing_block.py
@@ -2,6 +2,7 @@
 Module to define a two layer block similar to a BasicBlock in ResNet.
 """
 
+from typing import Any
 from warnings import warn
 
 import torch
@@ -106,6 +107,29 @@ class GrowingBlock(GrowingContainer):
             )
         else:
             raise ValueError("verbose must be a non-negative integer.")
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "optimal_delta_layer":
+            # We can't use directly @optimal_delta_layer.setter because of
+            # inheritance issues. But we want to be able to set this attribute
+            # so we use a @.setter to indicate it to the linter and redirect here.
+            GrowingBlock.optimal_delta_layer.fset(self, value)  # type: ignore
+        else:
+            return super().__setattr__(name, value)
+
+    @property
+    def optimal_delta_layer(self) -> torch.nn.Module | None:
+        """
+        Get the optimal delta layer of the block.
+        """
+        return self.second_layer.optimal_delta_layer
+
+    @optimal_delta_layer.setter
+    def optimal_delta_layer(self, value: torch.nn.Module | None):
+        """
+        Set the optimal delta layer of the block.
+        """
+        self.second_layer.optimal_delta_layer = value
 
     @property
     def hidden_features(self) -> int:

--- a/src/gromo/containers/growing_block.py
+++ b/src/gromo/containers/growing_block.py
@@ -159,12 +159,12 @@ class GrowingBlock(GrowingContainer):
         """
         if isinstance(value, float):
             value = torch.tensor(value, device=self.device)
-        elif isinstance(value, torch.Tensor):
-            self.second_layer.parameter_update_decrease = value
-        else:
+        elif not isinstance(value, torch.Tensor):
             raise TypeError(
                 "parameter_update_decrease must be a float or a torch.Tensor."
             )
+
+        self.second_layer.parameter_update_decrease = value
 
     @property
     def scaling_factor(self):

--- a/src/gromo/containers/resnet.py
+++ b/src/gromo/containers/resnet.py
@@ -141,6 +141,7 @@ class ResNetBasicBlock(SequentialGrowingContainer):
                     ),
                     extended_mid_activation=self.activation,
                     name=f"Stage {i} Block 0",
+                    target_hidden_channels=output_channels,
                     downsample=(
                         nn.Sequential(
                             nn.BatchNorm2d(input_channels, device=self.device),
@@ -224,6 +225,7 @@ class ResNetBasicBlock(SequentialGrowingContainer):
             ),
             extended_mid_activation=self.activation,
             name=f"Stage {stage_index} Block {len(stage)}",
+            target_hidden_channels=output_channels,
             device=self.device,
         )
         stage.append(new_block)
@@ -250,15 +252,6 @@ class ResNetBasicBlock(SequentialGrowingContainer):
                 x = block.extended_forward(x)
         x = self.post_net(x)
         return x
-
-    def number_of_neurons_to_add(  # pyright: ignore[reportIncompatibleMethodOverride]
-        self, growth_step=1
-    ) -> int:
-        """Get the number of neurons to add in the next growth step."""
-        layer = self._growable_layers[self.layer_to_grow_index]
-        return (
-            layer.out_features - int(layer.out_features * self.reduction_factor)
-        ) // growth_step
 
 
 def init_full_resnet_structure(

--- a/src/gromo/containers/resnet.py
+++ b/src/gromo/containers/resnet.py
@@ -341,13 +341,14 @@ def init_full_resnet_structure(
         raise TypeError(
             f"number_of_blocks_per_stage must be an int or a tuple of {nb_stages} ints."
         )
-    # Append additional blocks to complete each stage according to number_of_blocks_per_stage
+    # Append additional blocks to complete each stage according
+    #  to number_of_blocks_per_stage
     for stage_index in range(nb_stages):
         for _ in range(1, blocks_per_stage[stage_index]):
             model.append_block(
                 stage_index=stage_index,
                 input_block_kernel_size=input_block_kernel_size,
                 output_block_kernel_size=output_block_kernel_size,
-                hidden_channels=int(model.stages[stage_index][0].hidden_features),  # type: ignore
+                hidden_channels=int(model.stages[stage_index][0].hidden_neurons),  # type: ignore
             )
     return model

--- a/src/gromo/containers/sequential_growing_container.py
+++ b/src/gromo/containers/sequential_growing_container.py
@@ -59,6 +59,7 @@ class SequentialGrowingContainer(GrowingContainer):
             )
             self._growing_layers = [self._growable_layers[self.layer_to_grow_index]]
         elif scheduling_method == "all":
+            self.layer_to_grow_index = -1
             self._growing_layers = (  # pyright: ignore[reportIncompatibleVariableOverride]
                 self._growable_layers
             )
@@ -72,7 +73,14 @@ class SequentialGrowingContainer(GrowingContainer):
 
     def number_of_neurons_to_add(self, **kwargs) -> int:
         """Get the number of neurons to add in the next growth step."""
-        raise NotImplementedError
+        assert self.layer_to_grow_index >= 0, (
+            "layer_to_grow_index must be set to a valid index before calling "
+            "number_of_neurons_to_add. May indicate that multiple layers are being grown "
+            "at once, which is not supported by this method."
+        )
+        return self._growable_layers[self.layer_to_grow_index].number_of_neurons_to_add(
+            **kwargs
+        )
 
     def update_information(self) -> dict[str, Any]:
         """Get information about the current state of the growing layers."""
@@ -88,3 +96,12 @@ class SequentialGrowingContainer(GrowingContainer):
             }
             information[i] = layer_information
         return information
+
+    def missing_neurons(self) -> int:
+        """Get the number of missing neurons to reach the target size."""
+        return self.currently_updated_layer.missing_neurons()
+
+    def complete_growth(self, extension_kwargs: dict) -> None:
+        """Complete the growth to the target size."""
+        for layer in self._growable_layers:
+            layer.complete_growth(extension_kwargs=extension_kwargs)

--- a/src/gromo/containers/sequential_growing_container.py
+++ b/src/gromo/containers/sequential_growing_container.py
@@ -73,11 +73,13 @@ class SequentialGrowingContainer(GrowingContainer):
 
     def number_of_neurons_to_add(self, **kwargs) -> int:
         """Get the number of neurons to add in the next growth step."""
-        assert self.layer_to_grow_index >= 0, (
-            "layer_to_grow_index must be set to a valid index before calling "
-            "number_of_neurons_to_add. May indicate that multiple layers are being grown "
-            "at once, which is not supported by this method."
-        )
+        if self.layer_to_grow_index < 0:
+            raise RuntimeError(
+                "number_of_neurons_to_add is only supported when a single layer is being "
+                "grown (e.g. with scheduling_method='sequential'). A negative "
+                "layer_to_grow_index usually indicates that multiple layers are being "
+                "grown at once, which is not supported by this method."
+            )
         return self._growable_layers[self.layer_to_grow_index].number_of_neurons_to_add(
             **kwargs
         )

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -556,33 +556,38 @@ class GrowingModule(torch.nn.Module):
         initial_in_neurons: int | None = None,
     ) -> None:
         """
-        Initialize a GrowingModule.
+                Initialize a GrowingModule.
 
-        Parameters
-        ----------
-        layer: torch.nn.Module
-            layer of the module
-        tensor_s_shape: tuple[int, int] | None
-            shape of the tensor S
-        tensor_m_shape: tuple[int, int] | None
-            shape of the tensor M
-        post_layer_function: torch.nn.Module
-            function to apply after the layer
-        allow_growing: bool
-            if True, the module can grow (require a previous GrowingModule)
-        previous_module: torch.nn.Module | None
-            previous module
-        next_module: torch.nn.Module | None
-            next module
-        device: torch.device | None
-            device to use
-        name: str | None
-            name of the module
-        target_in_neurons: int | None
-            target number of input neurons for the layer at the end of the growth process
-        initial_in_neurons: int | None
-            initial number of input neurons for the layer at the beginning of the growth
-            process
+                Parameters
+                ----------
+                layer: torch.nn.Module
+                    layer of the module
+                tensor_s_shape: tuple[int, int] | None
+                    shape of the tensor S
+                tensor_m_shape: tuple[int, int] | None
+                    shape of the tensor M
+                post_layer_function: torch.nn.Module
+                    function to apply after the layer
+                allow_growing: bool
+                    if True, the module can grow (require a previous GrowingModule)
+                previous_module: torch.nn.Module | None
+                    previous module
+                next_module: torch.nn.Module | None
+                    next module
+                device: torch.device | None
+                    device to use
+                name: str | None
+                    name of the module
+        <<<<<<< HEAD
+                target_in_neurons: int | None
+                    target number of input neurons for the layer at the end of the growth process
+                initial_in_neurons: int | None
+                    initial number of input neurons for the layer at the beginning of the growth
+                    process
+        =======
+                target_in_features: int | None
+                    target number of input features for the layer at the end of the growth process
+        >>>>>>> 7b146f59 (feat: Add methods `missing_neurons`,  `number_of_neurons_to_add` and `complete_growth`)
         """
         if tensor_s_shape is None:
             warnings.warn(

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -556,38 +556,33 @@ class GrowingModule(torch.nn.Module):
         initial_in_neurons: int | None = None,
     ) -> None:
         """
-                Initialize a GrowingModule.
+        Initialize a GrowingModule.
 
-                Parameters
-                ----------
-                layer: torch.nn.Module
-                    layer of the module
-                tensor_s_shape: tuple[int, int] | None
-                    shape of the tensor S
-                tensor_m_shape: tuple[int, int] | None
-                    shape of the tensor M
-                post_layer_function: torch.nn.Module
-                    function to apply after the layer
-                allow_growing: bool
-                    if True, the module can grow (require a previous GrowingModule)
-                previous_module: torch.nn.Module | None
-                    previous module
-                next_module: torch.nn.Module | None
-                    next module
-                device: torch.device | None
-                    device to use
-                name: str | None
-                    name of the module
-        <<<<<<< HEAD
-                target_in_neurons: int | None
-                    target number of input neurons for the layer at the end of the growth process
-                initial_in_neurons: int | None
-                    initial number of input neurons for the layer at the beginning of the growth
-                    process
-        =======
-                target_in_features: int | None
-                    target number of input features for the layer at the end of the growth process
-        >>>>>>> 7b146f59 (feat: Add methods `missing_neurons`,  `number_of_neurons_to_add` and `complete_growth`)
+        Parameters
+        ----------
+        layer: torch.nn.Module
+            layer of the module
+        tensor_s_shape: tuple[int, int] | None
+            shape of the tensor S
+        tensor_m_shape: tuple[int, int] | None
+            shape of the tensor M
+        post_layer_function: torch.nn.Module
+            function to apply after the layer
+        allow_growing: bool
+            if True, the module can grow (require a previous GrowingModule)
+        previous_module: torch.nn.Module | None
+            previous module
+        next_module: torch.nn.Module | None
+            next module
+        device: torch.device | None
+            device to use
+        name: str | None
+            name of the module
+        target_in_neurons: int | None
+            target number of input neurons for the layer at the end of the growth process
+        initial_in_neurons: int | None
+            initial number of input neurons for the layer at the beginning of the growth
+            process
         """
         if tensor_s_shape is None:
             warnings.warn(

--- a/tests/test_growing_block.py
+++ b/tests/test_growing_block.py
@@ -738,6 +738,49 @@ class TestLinearGrowingBlock(TorchTestCase):
         self.assertEqual(block.scaling_factor, new_scaling_factor)
         self.assertEqual(block.second_layer.scaling_factor, new_scaling_factor)
 
+    def test_parameter_update_decrease_setter(self):
+        """Test parameter_update_decrease setter with Tensor and float."""
+        block = LinearGrowingBlock(
+            in_features=self.in_features,
+            out_features=self.in_features,
+            hidden_features=self.hidden_features,
+            device=self.device,
+        )
+
+        # Test setter with Tensor
+        tensor_value = torch.tensor(0.5, device=self.device)
+        block.parameter_update_decrease = tensor_value
+        self.assertIsInstance(block.parameter_update_decrease, torch.Tensor)
+        assert isinstance(block.parameter_update_decrease, torch.Tensor)  # type check
+        self.assertEqual(
+            block.second_layer.parameter_update_decrease.item(),
+            tensor_value.item(),
+        )
+
+        # Test setter with float (should convert to tensor)
+        float_value = 0.3
+        block.parameter_update_decrease = float_value
+        # Note: The float branch creates a tensor but doesn't assign it
+        # This test covers the isinstance(value, float) branch
+
+        # Test setter with invalid type
+        with self.assertRaises(TypeError):
+            block.parameter_update_decrease = "invalid"  # type: ignore
+
+    def test_set_scaling_factor_method(self):
+        """Test set_scaling_factor method."""
+        block = LinearGrowingBlock(
+            in_features=self.in_features,
+            out_features=self.in_features,
+            hidden_features=self.hidden_features,
+            device=self.device,
+        )
+
+        # Test set_scaling_factor method
+        new_factor = 0.7
+        block.set_scaling_factor(new_factor)
+        self.assertEqual(block.second_layer.scaling_factor, new_factor)
+
     @unittest_parametrize(({"hidden_features": 0}, {"hidden_features": 3}))
     def test_init_computation(self, hidden_features: int = 0):
         """Test initialization of computation."""

--- a/tests/test_growing_block.py
+++ b/tests/test_growing_block.py
@@ -751,7 +751,7 @@ class TestLinearGrowingBlock(TorchTestCase):
         tensor_value = torch.tensor(0.5, device=self.device)
         block.parameter_update_decrease = tensor_value
         self.assertIsInstance(block.parameter_update_decrease, torch.Tensor)
-        assert isinstance(block.parameter_update_decrease, torch.Tensor)  # type check
+        assert isinstance(block.second_layer.parameter_update_decrease, torch.Tensor)
         self.assertEqual(
             block.second_layer.parameter_update_decrease.item(),
             tensor_value.item(),
@@ -760,8 +760,10 @@ class TestLinearGrowingBlock(TorchTestCase):
         # Test setter with float (should convert to tensor)
         float_value = 0.3
         block.parameter_update_decrease = float_value
-        # Note: The float branch creates a tensor but doesn't assign it
-        # This test covers the isinstance(value, float) branch
+        self.assertEqual(
+            block.second_layer.parameter_update_decrease.item(),
+            float_value,
+        )
 
         # Test setter with invalid type
         with self.assertRaises(TypeError):
@@ -1202,9 +1204,6 @@ class TestLinearGrowingBlock(TorchTestCase):
             original_first_out = block.first_layer.out_features
             original_second_in = block.second_layer.in_features
 
-            # Note: extension_size just tells the block how many neurons are
-            # being added (updates hidden_features), but all neurons from the
-            # extension layer are still used
             # Create second extension without bias as required by apply_change
             second_extension_no_bias = torch.nn.Linear(
                 self.added_features,
@@ -1226,7 +1225,7 @@ class TestLinearGrowingBlock(TorchTestCase):
 
             # Apply change with explicit size
             # This should add self.added_features (7) to the layers, and
-            # update hidden_features by extension_size
+            # update hidden_features by the same amount
             explicit_size = block.second_layer.extended_input_layer.in_features
             block.apply_change(extension_size=explicit_size)
 

--- a/tests/test_growing_block.py
+++ b/tests/test_growing_block.py
@@ -760,7 +760,7 @@ class TestLinearGrowingBlock(TorchTestCase):
         # Test setter with float (should convert to tensor)
         float_value = 0.3
         block.parameter_update_decrease = float_value
-        self.assertEqual(
+        self.assertAlmostEqual(
             block.second_layer.parameter_update_decrease.item(),
             float_value,
         )

--- a/tests/test_growing_block.py
+++ b/tests/test_growing_block.py
@@ -1145,20 +1145,20 @@ class TestLinearGrowingBlock(TorchTestCase):
         3. Neither extension_size nor eigenvalues_extension (should raise
            assertion)
         """
-        # Setup: Create a block with some initial hidden features
-        initial_hidden_features = 2
-        block = LinearGrowingBlock(
-            in_features=self.in_features,
-            out_features=self.in_features,
-            hidden_features=initial_hidden_features,
-            device=self.device,
-        )
-
-        # Store original dimensions
-        original_first_out = block.first_layer.out_features
-        original_second_in = block.second_layer.in_features
-
         with self.subTest("Case 1: Explicit extension_size parameter"):
+            # Setup: Create a block with some initial hidden features
+            initial_hidden_features = 2
+            block = LinearGrowingBlock(
+                in_features=self.in_features,
+                out_features=self.in_features,
+                hidden_features=initial_hidden_features,
+                device=self.device,
+            )
+
+            # Store original dimensions
+            original_first_out = block.first_layer.out_features
+            original_second_in = block.second_layer.in_features
+
             # Note: extension_size just tells the block how many neurons are
             # being added (updates hidden_features), but all neurons from the
             # extension layer are still used
@@ -1184,7 +1184,7 @@ class TestLinearGrowingBlock(TorchTestCase):
             # Apply change with explicit size
             # This should add self.added_features (7) to the layers, and
             # update hidden_features by extension_size
-            explicit_size = 2
+            explicit_size = block.second_layer.extended_input_layer.in_features
             block.apply_change(extension_size=explicit_size)
 
             # Verify dimensions increased by the actual number of neurons

--- a/tests/test_growing_block.py
+++ b/tests/test_growing_block.py
@@ -1419,3 +1419,26 @@ class TestLinearGrowingBlock(TorchTestCase):
         self.assertIsInstance(
             stats, dict, "weights_statistics should return a dictionary"
         )
+
+    def test_optimal_delta_layer_property(self):
+        """Test optimal_delta_layer getter and setter."""
+        block = LinearGrowingBlock(
+            in_features=self.in_features,
+            out_features=self.in_features,
+            hidden_features=self.hidden_features,
+            device=self.device,
+        )
+
+        # Test getter - initially should be None
+        self.assertIsNone(block.optimal_delta_layer)
+
+        # Test setter by calling the property setter directly
+        # (nn.Module.__setattr__ intercepts normal assignments)
+        delta_layer = torch.nn.Linear(self.hidden_features, self.in_features)
+        block.optimal_delta_layer = delta_layer
+        self.assertIs(block.optimal_delta_layer, delta_layer)
+        self.assertIs(block.second_layer.optimal_delta_layer, delta_layer)
+
+        # Test setter with None
+        block.optimal_delta_layer = None
+        self.assertIsNone(block.optimal_delta_layer)

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -311,7 +311,7 @@ class TestResNet(TorchTestCase):
         # The first growable layer is the first block of the first stage
         # With reduction_factor=0.5, it should have 32 hidden features (64 * 0.5)
         # And out_features is 64 for the first stage
-        # So number to add should be (64 - 32) = 32 with growth_step=1
+        # So with number_of_growth_steps=1, number to add should be (64 - 32) = 32
         model.layer_to_grow_index = 0
 
         neurons_to_add = model.number_of_neurons_to_add(number_of_growth_steps=5)
@@ -320,6 +320,10 @@ class TestResNet(TorchTestCase):
             int,
             "number_of_neurons_to_add should return an integer",
         )
+
+        model.set_growing_layers(scheduling_method="all")
+        with self.assertRaises(RuntimeError):
+            model.number_of_neurons_to_add(number_of_growth_steps=2)
 
     def test_get_first_order_improvement(self):
         """Test the get_first_order_improvement method."""

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -353,3 +353,76 @@ class TestResNet(TorchTestCase):
             update_decrease + sum(x**2 for x in eigenvalues),
             msg="First order improvement calculation is incorrect",
         )
+
+    def test_missing_neurons(self):
+        """Test the missing_neurons method for SequentialGrowingContainer."""
+        device = torch.device("cpu")
+
+        # Create a small network
+        model = init_full_resnet_structure(
+            input_shape=(3, 32, 32),
+            out_features=10,
+            number_of_blocks_per_stage=1,
+            reduction_factor=0.5,
+            inplanes=4,
+            nb_stages=2,
+            device=device,
+        )
+
+        # Set a specific layer to grow (must set currently_updated_layer_index)
+        model.set_growing_layers(scheduling_method="sequential", index=0)
+        model.currently_updated_layer_index = 0
+
+        # Test missing_neurons returns an integer
+        missing = model.missing_neurons()
+        self.assertIsInstance(
+            missing,
+            int,
+            "missing_neurons should return an integer",
+        )
+        self.assertGreaterEqual(
+            missing,
+            0,
+            "missing_neurons should return a non-negative integer",
+        )
+
+    def test_complete_growth(self):
+        """Test the complete_growth method for SequentialGrowingContainer."""
+        device = torch.device("cpu")
+
+        # Create a small network
+        model = init_full_resnet_structure(
+            input_shape=(3, 32, 32),
+            out_features=10,
+            number_of_blocks_per_stage=1,
+            reduction_factor=0.5,
+            inplanes=4,
+            nb_stages=2,
+            device=device,
+        )
+
+        # Verify that the model has growable layers
+        self.assertGreater(
+            len(model._growable_layers),
+            0,
+            "Model should have growable layers",
+        )
+
+        # Get initial hidden neurons for the first block
+        first_block: RestrictedConv2dGrowingBlock = model.stages[0][0]  # type: ignore
+        initial_neurons = first_block.hidden_neurons
+
+        # Call complete_growth with extension kwargs (without extension_size)
+        extension_kwargs = {
+            "output_extension_init": "zeros",
+            "input_extension_init": "zeros",
+        }
+        model.complete_growth(extension_kwargs=extension_kwargs)
+
+        # Verify that hidden neurons increased
+        new_neurons = first_block.hidden_neurons
+        self.assertGreater(
+            new_neurons,
+            initial_neurons,
+            "complete_growth should increase the number of hidden neurons",
+        )

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -314,7 +314,7 @@ class TestResNet(TorchTestCase):
         # So number to add should be (64 - 32) = 32 with growth_step=1
         model.layer_to_grow_index = 0
 
-        neurons_to_add = model.number_of_neurons_to_add(growth_step=5)
+        neurons_to_add = model.number_of_neurons_to_add(number_of_growth_steps=5)
         self.assertIsInstance(
             neurons_to_add,
             int,


### PR DESCRIPTION
Made the `GrowingBlock` compatible with PR #170, #157, #148 and #164.

It's technically a breaking-change PR because the argument of `number_of_neurons_to_add` is changed to `number_of_growth_steps` and `hidden_features` is less sensible to bugs.