### PR TITLE
feat: Add a way to count `in_neurons` and store a target `in_neurons`

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -20,6 +20,7 @@ Develop branch
 Enhancements
 ~~~~~~~~~~~~
 
+- Add `in_neurons` property and `target_in_neurons` parameter to `GrowingModule`, `LinearGrowingModule`, and `Conv2dGrowingModule` for tracking neuron counts during growth. Add `missing_neurons`, `number_of_neurons_to_add`, and `complete_growth` methods to simplify multi-step growth processes (:gh:`187` by `Théo Rudkiewicz`_)
 - Update `output_volume` in `Conv2dMergeGrowingModule` based on post_merge_function and reshaping (:gh:`177` by `Stella Douka`_)
 - Implement lazy loading datasets that read directly from the disk (:gh:`169` by `Stella Douka`_)
 - Modify `in_channels` and `out_channels` as properties in `Conv2dGrowingModule` (:gh:`174` by `Stella Douka`_)

--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -521,6 +521,7 @@ class Conv2dGrowingModule(GrowingModule):
         allow_growing: bool = False,
         device: torch.device | None = None,
         name: str | None = None,
+        target_in_channels: int | None = None,
     ) -> None:
         if isinstance(kernel_size, int):
             kernel_size = (kernel_size, kernel_size)
@@ -550,6 +551,8 @@ class Conv2dGrowingModule(GrowingModule):
             ),
             device=device,
             name=name,
+            target_in_neurons=target_in_channels,
+            initial_in_neurons=in_channels,
         )
         self.layer: torch.nn.Conv2d
         self.kernel_size = self.layer.kernel_size
@@ -1143,6 +1146,7 @@ class RestrictedConv2dGrowingModule(Conv2dGrowingModule):
         allow_growing: bool = False,
         device: torch.device | None = None,
         name: str | None = None,
+        target_in_channels: int | None = None,
     ) -> None:
         super(RestrictedConv2dGrowingModule, self).__init__(
             in_channels=in_channels,
@@ -1160,6 +1164,7 @@ class RestrictedConv2dGrowingModule(Conv2dGrowingModule):
             allow_growing=allow_growing,
             device=device,
             name=name,
+            target_in_channels=target_in_channels,
         )
         self.bordering_convolution = None
 
@@ -1557,6 +1562,7 @@ class FullConv2dGrowingModule(Conv2dGrowingModule):
         allow_growing: bool = False,
         device: torch.device | None = None,
         name: str | None = None,
+        target_in_channels: int | None = None,
     ) -> None:
         super(FullConv2dGrowingModule, self).__init__(
             in_channels=in_channels,
@@ -1574,6 +1580,7 @@ class FullConv2dGrowingModule(Conv2dGrowingModule):
             allow_growing=allow_growing,
             device=device,
             name=name,
+            target_in_channels=target_in_channels,
         )
         self._mask_tensor_t: torch.Tensor | None = None
         self._tensor_s_growth = TensorStatistic(

--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -566,6 +566,10 @@ class Conv2dGrowingModule(GrowingModule):
     # activation function as the post_layer_function
 
     @property
+    def in_neurons(self) -> int:
+        return self.in_channels
+
+    @property
     def in_channels(self):
         return self.layer.in_channels
 

--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -501,6 +501,8 @@ class Conv2dGrowingModule(GrowingModule):
         device for the layer
     name: str | None
         name of the layer used for debugging purpose
+    target_in_channels: int | None
+        target number of input channels for the layer when growing is performed
     """
 
     def __init__(

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -2412,7 +2412,7 @@ class GrowingModule(torch.nn.Module):
         """
         if self.target_in_neurons is None:
             raise ValueError(
-                "Target hidden features is not set, cannot compute missing neurons."
+                "Target in neurons is not set, cannot compute missing neurons."
             )
         return self.target_in_neurons - self.in_neurons
 

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -579,7 +579,10 @@ class GrowingModule(torch.nn.Module):
         name: str | None
             name of the module
         target_in_neurons: int | None
-            target number of input features for the layer at the end of the growth process
+            target number of input neurons for the layer at the end of the growth process
+        initial_in_neurons: int | None
+            initial number of input neurons for the layer at the beginning of the growth
+            process
         """
         if tensor_s_shape is None:
             warnings.warn(
@@ -880,9 +883,9 @@ class GrowingModule(torch.nn.Module):
         if key == "store_input" and value is not self.store_input:
             self.__dict__["store_input"] = value
             if isinstance(self.previous_module, MergeGrowingModule):
-                # As a MergeGrowingModule may have multiple next modules
-                # we need to keep track of the number of modules that require the activity
-                # to be stored. Hence we store it as long as one of the module requires it.
+                # As a MergeGrowingModule may have multiple next modules we need to
+                # keep track of the number of modules that require the activity to be
+                # stored. Hence we store it as long as one of the module requires it.
                 self.previous_module.store_activity += 1 if value else -1
             else:
                 self._internal_store_input = value
@@ -915,7 +918,8 @@ class GrowingModule(torch.nn.Module):
                 pass
             else:
                 raise TypeError(
-                    f"Previous module must be a GrowingModule or MergeGrowingModule, got {type(self.previous_module)}"
+                    f"Previous module must be a GrowingModule or MergeGrowingModule, "
+                    f"got {type(self.previous_module)}"
                 )
         elif key == "weight":
             self.layer.weight = value
@@ -1016,7 +1020,8 @@ class GrowingModule(torch.nn.Module):
             else:
                 if x_ext is not None:  # TODO: and is not empty
                     warnings.warn(
-                        f"x_ext must be None got {x_ext} for {self.name}. As the input is not extended, no extension is needed.",
+                        f"x_ext must be None got {x_ext} for {self.name}. As the input "
+                        f"is not extended, no extension is needed.",
                         UserWarning,
                     )
 
@@ -1041,7 +1046,8 @@ class GrowingModule(torch.nn.Module):
         force_update: bool = True,
     ) -> tuple[int, ...] | None:
         """
-        Update the input size of the layer. Either according to the parameter or the input currently stored.
+        Update the input size of the layer. Either according to the parameter or
+        the input currently stored.
 
         Parameters
         ----------
@@ -1130,7 +1136,8 @@ class GrowingModule(torch.nn.Module):
     # Statistics computation
     def projected_v_goal(self, input_vector: torch.Tensor) -> torch.Tensor:
         """
-        Compute the projected gradient of the goal with respect to the activity of the layer.
+        Compute the projected gradient of the goal with respect to the activity
+        of the layer.
 
         dLoss/dA_proj := dLoss/dA - dW B[-1] where A is the pre-activation vector of the
         layer, and dW the optimal delta for the layer
@@ -1194,12 +1201,13 @@ class GrowingModule(torch.nn.Module):
             return self.previous_module.tensor_s
         elif isinstance(self.previous_module, MergeGrowingModule):
             raise NotImplementedError(
-                f"S growth is not implemented for module preceded by an MergeGrowingModule."
-                f" (error in {self.name})"
+                f"S growth is not implemented for module preceded by an "
+                f"MergeGrowingModule. (error in {self.name})"
             )
         else:
             raise NotImplementedError(
-                f"S growth is not implemented yet for {type(self.previous_module)} as previous module."
+                f"S growth is not implemented yet for {type(self.previous_module)} "
+                f"as previous module."
             )
 
     @tensor_s_growth.setter
@@ -1209,7 +1217,8 @@ class GrowingModule(torch.nn.Module):
         """
         raise AttributeError(
             f"You tried to set tensor_s_growth of a GrowingModule (name={self.name})."
-            "This is not allowed because tensor_s_growth refers to the previous module's tensor_s, not the current module's tensor_s."
+            f"This is not allowed because tensor_s_growth refers to the previous module's"
+            f" tensor_s, not the current module's tensor_s."
         )
 
     def compute_m_update(
@@ -1516,8 +1525,8 @@ class GrowingModule(torch.nn.Module):
                 < 1e-4
             ):
                 warnings.warn(
-                    f"Scaling factor {scaling_factor} is different from the one "
-                    f"used during the extended_forward {self._scaling_factor_next_module}."
+                    f"Scaling factor {scaling_factor} is different from the one used"
+                    f" during the extended_forward {self._scaling_factor_next_module}."
                 )
         if extension_size > 0 or self.extended_output_layer is not None:
             assert isinstance(self.extended_output_layer, torch.nn.Module), (
@@ -1598,7 +1607,8 @@ class GrowingModule(torch.nn.Module):
                 ), "The bias of the input extension must be null."
                 if self.scaling_factor == 0:
                     warnings.warn(
-                        "The scaling factor is null. The input extension will have no effect."
+                        "The scaling factor is null. "
+                        "The input extension will have no effect."
                     )
                 self.layer_in_extension(
                     weight=sqrt_factor * self.extended_input_layer.weight
@@ -1610,8 +1620,8 @@ class GrowingModule(torch.nn.Module):
                         if extension_size is None:
                             assert self.eigenvalues_extension is not None, (
                                 "We need to determine the size of the extension but "
-                                "it was not given as parameter nor could be automatically "
-                                "determined as self.eigenvalues_extension is None"
+                                "it was not given as parameter nor could be automatically"
+                                " determined as self.eigenvalues_extension is None"
                                 f"(Error occurred in {self.name})"
                             )
                             extension_size = self.eigenvalues_extension.shape[0]
@@ -1667,7 +1677,8 @@ class GrowingModule(torch.nn.Module):
         Returns
         -------
         tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | float]
-            optimal delta for the weights, the biases if needed and the first order decrease
+            optimal delta for the weights, the biases if needed and
+            the first order decrease
         """
         tensor_s = self.tensor_s()
         tensor_m = self.tensor_m()
@@ -1703,7 +1714,8 @@ class GrowingModule(torch.nn.Module):
         Parameters
         ----------
         numerical_threshold: float
-            threshold to consider an eigenvalue as zero in the square root of the inverse of S
+            threshold to consider an eigenvalue as zero in the square root of
+            the inverse of S
         statistical_threshold: float
             threshold to consider an eigenvalue as zero in the SVD of S{-1/2} N
         maximum_added_neurons: int | None
@@ -1766,7 +1778,8 @@ class GrowingModule(torch.nn.Module):
         Parameters
         ----------
         numerical_threshold: float
-            threshold to consider an eigenvalue as zero in the square root of the inverse of S
+            threshold to consider an eigenvalue as zero in the square root of
+            the inverse of S
         statistical_threshold: float
             threshold to consider an eigenvalue as zero in the SVD of S{-1/2} N
         maximum_added_neurons: int | None
@@ -1822,7 +1835,8 @@ class GrowingModule(torch.nn.Module):
         Parameters
         ----------
         numerical_threshold: float
-            threshold to consider an eigenvalue as zero in the square root of the inverse of S
+            threshold to consider an eigenvalue as zero in the square root of
+            the inverse of S
         statistical_threshold: float
             threshold to consider an eigenvalue as zero in the SVD of S{-1/2} N
         maximum_added_neurons: int | None
@@ -1944,9 +1958,11 @@ class GrowingModule(torch.nn.Module):
         Raises
         ------
         NotImplementedError
-            raised when include_previous is True and the previous module is of type MergeGrowingModule
+            raised when include_previous is True and the previous module is
+            of type MergeGrowingModule
         TypeError
-            raised when the previous module is not of type GrowingModule or MergeGrowingModule
+            raised when the previous module is not of type GrowingModule
+            or MergeGrowingModule
         """
         if delete_delta:
             self.optimal_delta_layer = None
@@ -1998,7 +2014,8 @@ class GrowingModule(torch.nn.Module):
                                 "This may lead to errors when using extended_forward.",
                                 UserWarning,
                             )
-                        # otherwise it is ok as user already deleted the extended_output_layer
+                        # otherwise it is ok as user already deleted
+                        # the extended_output_layer
                     elif isinstance(self.previous_module, MergeGrowingModule):
                         return
                         # the user intentionally decided to take care of deletion of the

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -578,7 +578,7 @@ class GrowingModule(torch.nn.Module):
             device to use
         name: str | None
             name of the module
-        target_in_features: int | None
+        target_in_neurons: int | None
             target number of input features for the layer at the end of the growth process
         """
         if tensor_s_shape is None:
@@ -2422,6 +2422,14 @@ class GrowingModule(torch.nn.Module):
         number_of_growth_steps: int = 1,
     ) -> int:
         """Get the number of neurons to add in the next growth step.
+
+        Methods
+        -------
+        - fixed_proportional: add a fixed proportion of the total number of neurons
+          to add at each growth step. The amount to add is computed as
+          an integer division as a consequence a few neurons may remain to be added
+          after all growth steps have been performed.
+
 
         Parameters
         ----------

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -699,6 +699,10 @@ class GrowingModule(torch.nn.Module):
         )
 
     @property
+    def in_neurons(self) -> int:
+        raise NotImplementedError
+
+    @property
     def in_features(self) -> int:
         raise NotImplementedError
 

--- a/src/gromo/modules/linear_growing_module.py
+++ b/src/gromo/modules/linear_growing_module.py
@@ -253,6 +253,7 @@ class LinearGrowingModule(GrowingModule):
         allow_growing: bool = False,
         device: torch.device | None = None,
         name: str | None = None,
+        target_in_features: int | None = None,
     ) -> None:
         super(LinearGrowingModule, self).__init__(
             layer=torch.nn.Linear(
@@ -267,6 +268,8 @@ class LinearGrowingModule(GrowingModule):
             tensor_m_shape=(in_features + use_bias, out_features),
             device=device,
             name=name,
+            target_in_neurons=target_in_features,
+            initial_in_neurons=in_features,
         )
         self.use_bias = use_bias
 

--- a/src/gromo/modules/linear_growing_module.py
+++ b/src/gromo/modules/linear_growing_module.py
@@ -277,6 +277,10 @@ class LinearGrowingModule(GrowingModule):
         return self.layer.in_features
 
     @property
+    def in_neurons(self) -> int:
+        return self.layer.in_features
+
+    @property
     def out_features(self) -> int:
         return self.layer.out_features
 

--- a/tests/test_conv2d_growing_module.py
+++ b/tests/test_conv2d_growing_module.py
@@ -2061,5 +2061,66 @@ class TestCreateLayerExtensionsConv2d(TestConv2dGrowingModuleBase):
             )
 
 
+class TestNeuronCountingConv2d(TestConv2dGrowingModuleBase):
+    """Test in_neurons property and growth-related methods for Conv2dGrowingModule."""
+
+    def test_in_neurons_returns_in_channels(self) -> None:
+        """Test that in_neurons returns in_channels for Conv2d modules."""
+        layer = Conv2dGrowingModule(
+            in_channels=5,
+            out_channels=3,
+            kernel_size=(3, 3),
+            device=global_device(),
+        )
+        self.assertEqual(layer.in_neurons, 5)
+        self.assertEqual(layer.in_neurons, layer.in_channels)
+
+    def test_target_in_channels_initialization(self) -> None:
+        """Test that target_in_neurons is correctly initialized via target_in_channels."""
+        # Without target
+        layer = Conv2dGrowingModule(
+            in_channels=5,
+            out_channels=3,
+            kernel_size=(3, 3),
+            device=global_device(),
+        )
+        self.assertIsNone(layer.target_in_neurons)
+        self.assertEqual(layer._initial_in_neurons, 5)
+
+        # With target
+        layer_with_target = Conv2dGrowingModule(
+            in_channels=5,
+            out_channels=3,
+            kernel_size=(3, 3),
+            target_in_channels=10,
+            device=global_device(),
+        )
+        self.assertEqual(layer_with_target.target_in_neurons, 10)
+        self.assertEqual(layer_with_target._initial_in_neurons, 5)
+
+    def test_missing_neurons_for_conv2d(self) -> None:
+        """Test missing_neurons for Conv2dGrowingModule."""
+        layer = Conv2dGrowingModule(
+            in_channels=5,
+            out_channels=3,
+            kernel_size=(3, 3),
+            target_in_channels=10,
+            device=global_device(),
+        )
+        self.assertEqual(layer.missing_neurons(), 5)
+
+    def test_number_of_neurons_to_add_for_conv2d(self) -> None:
+        """Test number_of_neurons_to_add for Conv2dGrowingModule."""
+        layer = Conv2dGrowingModule(
+            in_channels=5,
+            out_channels=3,
+            kernel_size=(3, 3),
+            target_in_channels=15,
+            device=global_device(),
+        )
+        # Total to add: 15 - 5 = 10
+        self.assertEqual(layer.number_of_neurons_to_add(number_of_growth_steps=2), 5)
+
+
 if __name__ == "__main__":
     main()

--- a/tests/test_linear_growing_module.py
+++ b/tests/test_linear_growing_module.py
@@ -3667,6 +3667,219 @@ class TestCreateLayerExtensions(TestLinearGrowingModuleBase):
             )
 
 
+class TestNeuronCountingAndGrowth(TestLinearGrowingModuleBase):
+    """Test in_neurons property and growth-related methods for LinearGrowingModule."""
+
+    def test_in_neurons_property(self) -> None:
+        """Test that in_neurons returns the number of input features."""
+        layer = LinearGrowingModule(
+            in_features=5,
+            out_features=3,
+            use_bias=True,
+            device=global_device(),
+        )
+        self.assertEqual(layer.in_neurons, 5)
+        self.assertEqual(layer.in_neurons, layer.in_features)
+
+    def test_target_in_neurons_initialization(self) -> None:
+        """Test that target_in_neurons is correctly initialized."""
+        # Without target
+        layer = LinearGrowingModule(
+            in_features=5,
+            out_features=3,
+            device=global_device(),
+        )
+        self.assertIsNone(layer.target_in_neurons)
+        self.assertEqual(layer._initial_in_neurons, 5)
+
+        # With target
+        layer_with_target = LinearGrowingModule(
+            in_features=5,
+            out_features=3,
+            target_in_features=10,
+            device=global_device(),
+        )
+        self.assertEqual(layer_with_target.target_in_neurons, 10)
+        self.assertEqual(layer_with_target._initial_in_neurons, 5)
+
+    def test_missing_neurons_without_target_raises_error(self) -> None:
+        """Test that missing_neurons raises ValueError when target is not set."""
+        layer = LinearGrowingModule(
+            in_features=5,
+            out_features=3,
+            device=global_device(),
+        )
+        with self.assertRaises(ValueError) as context:
+            layer.missing_neurons()
+        self.assertIn("Target in neurons is not set", str(context.exception))
+
+    def test_missing_neurons_with_target(self) -> None:
+        """Test that missing_neurons returns correct value when target is set."""
+        layer = LinearGrowingModule(
+            in_features=5,
+            out_features=3,
+            target_in_features=10,
+            device=global_device(),
+        )
+        self.assertEqual(layer.missing_neurons(), 5)
+
+    def test_missing_neurons_zero_when_at_target(self) -> None:
+        """Test missing_neurons returns 0 when already at target size."""
+        layer = LinearGrowingModule(
+            in_features=10,
+            out_features=3,
+            target_in_features=10,
+            device=global_device(),
+        )
+        self.assertEqual(layer.missing_neurons(), 0)
+
+    def test_number_of_neurons_to_add_without_target_raises_error(self) -> None:
+        """Test number_of_neurons_to_add raises ValueError when target is not set."""
+        layer = LinearGrowingModule(
+            in_features=5,
+            out_features=3,
+            device=global_device(),
+        )
+        with self.assertRaises(ValueError) as context:
+            layer.number_of_neurons_to_add()
+        self.assertIn("Target in neurons is not set", str(context.exception))
+
+    def test_number_of_neurons_to_add_without_initial_raises_error(self) -> None:
+        """Test number_of_neurons_to_add raises ValueError when initial is not set."""
+        layer = LinearGrowingModule(
+            in_features=5,
+            out_features=3,
+            target_in_features=10,
+            device=global_device(),
+        )
+        # Manually set _initial_in_neurons to None to simulate the edge case
+        layer._initial_in_neurons = None
+        with self.assertRaises(ValueError) as context:
+            layer.number_of_neurons_to_add()
+        self.assertIn("Initial in neurons is not set", str(context.exception))
+
+    def test_number_of_neurons_to_add_fixed_proportional(self) -> None:
+        """Test number_of_neurons_to_add with fixed_proportional method."""
+        layer = LinearGrowingModule(
+            in_features=5,
+            out_features=3,
+            target_in_features=15,
+            device=global_device(),
+        )
+        # Total to add: 15 - 5 = 10
+        # With 1 growth step: 10 // 1 = 10
+        self.assertEqual(layer.number_of_neurons_to_add(number_of_growth_steps=1), 10)
+        # With 2 growth steps: 10 // 2 = 5
+        self.assertEqual(layer.number_of_neurons_to_add(number_of_growth_steps=2), 5)
+        # With 3 growth steps: 10 // 3 = 3
+        self.assertEqual(layer.number_of_neurons_to_add(number_of_growth_steps=3), 3)
+
+    def test_number_of_neurons_to_add_unknown_method_raises_error(self) -> None:
+        """Test number_of_neurons_to_add raises ValueError for unknown method."""
+        layer = LinearGrowingModule(
+            in_features=5,
+            out_features=3,
+            target_in_features=10,
+            device=global_device(),
+        )
+        with self.assertRaises(ValueError) as context:
+            layer.number_of_neurons_to_add(method="unknown_method")
+        self.assertIn("Unknown method", str(context.exception))
+
+    def test_complete_growth_increases_in_features(self) -> None:
+        """Test that complete_growth grows the layer to target size."""
+        # Create two connected layers
+        # Using use_bias=False to avoid bias assertion in apply_change
+        layer1 = LinearGrowingModule(
+            in_features=5,
+            out_features=3,
+            target_in_features=6,
+            use_bias=False,
+            device=global_device(),
+            name="layer1",
+        )
+        layer2 = LinearGrowingModule(
+            in_features=3,
+            out_features=7,
+            target_in_features=6,
+            use_bias=False,
+            previous_module=layer1,
+            device=global_device(),
+            name="layer2",
+        )
+
+        # Verify initial state
+        self.assertEqual(layer2.in_features, 3)
+        self.assertEqual(layer2.missing_neurons(), 3)
+
+        # Complete growth
+        layer2.complete_growth(extension_kwargs={})
+
+        # Verify final state
+        self.assertEqual(layer2.in_features, 6)
+        self.assertEqual(layer1.out_features, 6)
+        self.assertEqual(layer2.missing_neurons(), 0)
+
+    def test_complete_growth_does_nothing_when_already_at_target(self) -> None:
+        """Test that complete_growth does nothing when layer is at target size."""
+        layer1 = LinearGrowingModule(
+            in_features=5,
+            out_features=3,
+            device=global_device(),
+            name="layer1",
+        )
+        layer2 = LinearGrowingModule(
+            in_features=3,
+            out_features=7,
+            target_in_features=3,
+            previous_module=layer1,
+            device=global_device(),
+            name="layer2",
+        )
+
+        # Verify initial state
+        initial_in_features = layer2.in_features
+
+        # Complete growth (should do nothing)
+        layer2.complete_growth(extension_kwargs={})
+
+        # Verify layer hasn't changed
+        self.assertEqual(layer2.in_features, initial_in_features)
+
+    def test_complete_growth_does_nothing_when_exceeding_target(self) -> None:
+        """Test that complete_growth does nothing when layer exceeds target size."""
+        layer1 = LinearGrowingModule(
+            in_features=5,
+            out_features=10,
+            device=global_device(),
+            name="layer1",
+        )
+        layer2 = LinearGrowingModule(
+            in_features=10,
+            out_features=7,
+            target_in_features=5,  # Target is less than current in_features
+            previous_module=layer1,
+            device=global_device(),
+            name="layer2",
+        )
+
+        # Verify initial state: in_features > target
+        self.assertEqual(layer2.in_features, 10)
+        self.assertEqual(layer2.target_in_neurons, 5)
+        self.assertEqual(layer2.missing_neurons(), -5)  # Negative means exceeds target
+
+        # Store initial features
+        initial_in_features = layer2.in_features
+        initial_out_features_layer1 = layer1.out_features
+
+        # Complete growth (should do nothing since we're already past target)
+        layer2.complete_growth(extension_kwargs={})
+
+        # Verify layers haven't changed
+        self.assertEqual(layer2.in_features, initial_in_features)
+        self.assertEqual(layer1.out_features, initial_out_features_layer1)
+
+
 if __name__ == "__main__":
     from unittest import main
 


### PR DESCRIPTION
This PR introduces neuron counting capabilities and growth tracking features to the GrowingModule framework. It adds the `in_neurons` property to provide a unified way to access input neuron counts across different module types (linear and convolutional), along with a `target_in_neurons` parameter to specify the desired final size during growth. Three new methods facilitate multi-step growth processes: `missing_neurons()` for computing remaining neurons to add, `number_of_neurons_to_add()` for calculating per-step additions, and `complete_growth()` for growing to the target size.