### PR TITLE
Εxtension of first dimension instead of last in GrowingLayerNorm

### DIFF
--- a/src/gromo/modules/growing_normalisation.py
+++ b/src/gromo/modules/growing_normalisation.py
@@ -104,7 +104,7 @@ class GrowingBatchNorm(nn.modules.batchnorm._BatchNorm):
             if new_values.device != device:
                 new_values = new_values.to(device)
             if new_values.dtype != current_param.dtype:
-                new_values.to(dtype=current_param.dtype)
+                new_values = new_values.to(dtype=current_param.dtype)
 
         # Concatenate old and new values
         assert new_values is not None  # Type hint for mypy
@@ -352,7 +352,7 @@ class GrowingLayerNorm(nn.LayerNorm):
             if new_values.device != device:
                 new_values = new_values.to(device)
             if new_values.dtype != current_param.dtype:
-                new_values.to(dtype=current_param.dtype)
+                new_values = new_values.to(dtype=current_param.dtype)
 
         assert new_values is not None
         with torch.no_grad():
@@ -557,7 +557,7 @@ class GrowingGroupNorm(nn.GroupNorm):
             if new_values.device != device:
                 new_values = new_values.to(device)
             if new_values.dtype != current_param.dtype:
-                new_values.to(dtype=current_param.dtype)
+                new_values = new_values.to(dtype=current_param.dtype)
 
         assert new_values is not None
         with torch.no_grad():

--- a/src/gromo/modules/growing_normalisation.py
+++ b/src/gromo/modules/growing_normalisation.py
@@ -325,7 +325,7 @@ class GrowingLayerNorm(nn.LayerNorm):
     def _extend_parameter(
         self,
         param_name: str,
-        additional_last_dim: int,
+        additional_first_dim: int,
         new_values: torch.Tensor | None,
         default_value_fn: Callable,
         device: torch.device,
@@ -336,8 +336,8 @@ class GrowingLayerNorm(nn.LayerNorm):
             return
 
         required_shape = (
-            *tuple(current_param.shape[:-1]),
-            additional_last_dim,
+            additional_first_dim,
+            *tuple(current_param.shape[1:]),
         )
 
         if new_values is None:
@@ -356,7 +356,7 @@ class GrowingLayerNorm(nn.LayerNorm):
 
         assert new_values is not None
         with torch.no_grad():
-            extended_param = torch.cat([current_param.detach(), new_values], dim=-1)
+            extended_param = torch.cat([current_param.detach(), new_values], dim=0)
 
         if as_parameter:
             setattr(self, param_name, nn.Parameter(extended_param))
@@ -365,42 +365,38 @@ class GrowingLayerNorm(nn.LayerNorm):
 
     def grow(
         self,
-        additional_last_dim: int,
+        additional_first_dim: int,
         new_weights: torch.Tensor | None = None,
         new_biases: torch.Tensor | None = None,
     ) -> None:
-        """Grow the LayerNorm by increasing the last dimension
+        """Grow the LayerNorm by increasing the first (channel) dimension
 
         Parameters
         ----------
-        additional_last_dim : int
-            number of additional features to add to last dimension
+        additional_first_dim : int
+            number of additional channels to add to the first dimension
         new_weights : torch.Tensor | None, optional
-            custom weights for the new features, if None defaults to ones, by default None
+            custom weights for the new channels, if None defaults to ones, by default None
         new_biases : torch.Tensor | None, optional
-            custom bias for the new features, if None defaults to zeros, by default None
+            custom bias for the new channels, if None defaults to zeros, by default None
 
         Raises
         ------
         ValueError
-            if the `additional_last_dim` is not positive
+            if the `additional_first_dim` is not positive
         """
-        if additional_last_dim <= 0:
+        if additional_first_dim <= 0:
             raise ValueError(
-                f"additional_last_dim must be positive, got {additional_last_dim}"
+                f"additional_first_dim must be positive, got {additional_first_dim}"
             )
 
         # Compute new normalized_shape without mutating yet
-        old = (
-            (self.normalized_shape,)
-            if isinstance(self.normalized_shape, int)
-            else tuple(int(v) for v in self.normalized_shape)
-        )
-        new_normalized_shape = (*tuple(old[:-1]), old[-1] + additional_last_dim)
+        old = tuple(int(v) for v in self.normalized_shape)
+        new_normalized_shape = (old[0] + additional_first_dim, *old[1:])
 
         # Validate custom tensor shapes before any mutation
         if getattr(self, "elementwise_affine", False):
-            weight_required_shape = (*tuple(self.weight.shape[:-1]), additional_last_dim)
+            weight_required_shape = (additional_first_dim, *tuple(self.weight.shape[1:]))
             if (
                 new_weights is not None
                 and tuple(new_weights.shape) != weight_required_shape
@@ -411,7 +407,7 @@ class GrowingLayerNorm(nn.LayerNorm):
                 )
 
             if getattr(self, "bias", None) is not None and new_biases is not None:
-                bias_required_shape = (*tuple(self.bias.shape[:-1]), additional_last_dim)
+                bias_required_shape = (additional_first_dim, *tuple(self.bias.shape[1:]))
                 if tuple(new_biases.shape) != bias_required_shape:
                     raise ValueError(
                         f"new_bias must have shape {bias_required_shape}, "
@@ -428,7 +424,7 @@ class GrowingLayerNorm(nn.LayerNorm):
 
             self._extend_parameter(
                 "weight",
-                additional_last_dim,
+                additional_first_dim,
                 new_weights,
                 torch.ones,
                 device,
@@ -437,7 +433,7 @@ class GrowingLayerNorm(nn.LayerNorm):
             if getattr(self, "bias", None) is not None:
                 self._extend_parameter(
                     "bias",
-                    additional_last_dim,
+                    additional_first_dim,
                     new_biases,
                     torch.zeros,
                     device,

--- a/tests/test_growing_normalisation.py
+++ b/tests/test_growing_normalisation.py
@@ -664,16 +664,21 @@ class TestGrowingLayerNorm(unittest.TestCase):
         self.assertEqual(output.shape, x.shape)
 
     def test_grow_multi_dim_normalized_shape(self):
-        """Test growing the last dim of a 2-D normalized_shape."""
+        """Test growing the first (channel) dim of a 2-D normalized_shape."""
         H, W = 8, 16
         ln = GrowingLayerNorm(normalized_shape=[H, W], device=self.device)
         additional = 8
 
         ln.grow(additional)
 
-        self.assertEqual(ln.normalized_shape, (H, W + additional))
-        self.assertEqual(ln.weight.shape, (H, W + additional))
-        self.assertEqual(ln.bias.shape, (H, W + additional))
+        self.assertEqual(ln.normalized_shape, (H + additional, W))
+        self.assertEqual(ln.weight.shape, (H + additional, W))
+        self.assertEqual(ln.bias.shape, (H + additional, W))
+
+        # Forward pass with correctly-grown input
+        x = torch.randn(self.batch_size, H + additional, W, device=self.device)
+        out = ln(x)
+        self.assertEqual(out.shape, x.shape)
 
     def test_grow_error_cases(self):
         """Test ValueError for non-positive additional_last_dim and wrong custom shapes."""
@@ -738,7 +743,7 @@ class TestGrowingLayerNorm(unittest.TestCase):
         )
         buffers = dict(ln.named_buffers())
         self.assertIn("running_stat", buffers)
-        self.assertEqual(buffers["running_stat"].shape[-1], self.initial_features + 8)
+        self.assertEqual(buffers["running_stat"].shape[0], self.initial_features + 8)
 
     def test_grow_device_inferred_from_weight(self):
         """Test that device is inferred from self.weight when not passed."""


### PR DESCRIPTION
The standard initialization of LayerNorm in pytorch is `nn.LayerNorm([C, H, W])`, suggesting that the number of channels appears in the first dimension. 
The current implementation of `GrowingLayerNorm` grows the last dimension, which is incompatible.

This was supposed to trigger an error, which for some reason was suppressed.