### PR TITLE
feat: add VGG

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -19,6 +19,8 @@ Develop branch
 
 Enhancements
 ~~~~~~~~~~~~
+
+
 - Introduce VGG-like growing architecture support with `VGG` and `_VGGStageBlock` classes(:gh:`236` by `Hugo Mousset`_)
 - Adds configurability to the ResNet container to allow using BatchNorm2d or disabling normalization entirely (:gh:`228` by `Théo Rudkiewicz`_)
 - Add ``uv`` files, use ``uv sync --extra dev --extra test --extra doc`` to install the package with all dependencies (:gh:`226` by `Théo Rudkiewicz`_)

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -21,7 +21,7 @@ Enhancements
 ~~~~~~~~~~~~
 
 
-- Introduce VGG-like growing architecture support with `VGG` and `_VGGStageBlock` classes(:gh:`236` by `Hugo Mousset`_)
+- Introduce VGG-like growing architecture support with the `VGG` class (:gh:`236` by `Hugo Mousset`_)
 - Adds configurability to the ResNet container to allow using BatchNorm2d or disabling normalization entirely (:gh:`228` by `Théo Rudkiewicz`_)
 - Add ``uv`` files, use ``uv sync --extra dev --extra test --extra doc`` to install the package with all dependencies (:gh:`226` by `Théo Rudkiewicz`_)
 - Use ``ruff`` for formatting (:gh:`227` by `Théo Rudkiewicz`_)

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -19,7 +19,7 @@ Develop branch
 
 Enhancements
 ~~~~~~~~~~~~
-
+- Introduce VGG-like growing architecture support with `VGG` and `_VGGStageBlock` classes(:gh:`236` by `Hugo Mousset`_)
 - Adds configurability to the ResNet container to allow using BatchNorm2d or disabling normalization entirely (:gh:`228` by `Théo Rudkiewicz`_)
 - Add ``uv`` files, use ``uv sync --extra dev --extra test --extra doc`` to install the package with all dependencies (:gh:`226` by `Théo Rudkiewicz`_)
 - Use ``ruff`` for formatting (:gh:`227` by `Théo Rudkiewicz`_)
@@ -129,3 +129,5 @@ API changes
 .. _Stella Douka: https://github.com/stelladk
 .. _Théo Rudkiewicz: https://github.com/TheoRudkiewicz
 .. _Stéphane Rivaud: https://github.com/streethagore
+.. _Félix Houdouin: https://github.com/Edarfix
+.. _Hugo Mousset: https://github.com/hmousset

--- a/src/gromo/containers/resnet.py
+++ b/src/gromo/containers/resnet.py
@@ -5,7 +5,7 @@ and to add basic blocks add the end of the stages.
 """
 
 from math import ceil
-from typing import Literal, TypeAlias, TypedDict
+from typing import Literal, TypeAlias
 
 import torch
 from torch import nn
@@ -16,45 +16,16 @@ from gromo.modules.conv2d_growing_module import (
     Conv2dGrowingModule,
     RestrictedConv2dGrowingModule,
 )
-from gromo.modules.growing_normalisation import GrowingBatchNorm2d, GrowingGroupNorm
+from gromo.modules.growing_normalisation import (
+    CompleteNormKwargs,
+    GrowingBatchNorm2d,
+    GrowingGroupNorm,
+    NormKwargs,
+    base_norm_kwargs,
+)
 
 
-class NormKwargs(TypedDict, total=False):
-    """Optional normalization configuration.
-
-    This is a superset of all normalization keyword arguments.
-    Each normalization type uses only the relevant keys:
-
-    - ``"batch"``: ``eps``, ``momentum``, ``affine``, ``track_running_stats``
-    - ``"group"``: ``num_groups``, ``eps``, ``affine``
-    """
-
-    eps: float
-    momentum: float
-    affine: bool
-    track_running_stats: bool
-    num_groups: int
-
-
-class CompleteNormKwargs(TypedDict):
-    """Complete normalization configuration (superset of all norm types)."""
-
-    eps: float
-    momentum: float
-    affine: bool
-    track_running_stats: bool
-    num_groups: int
-
-
-base_norm_kwargs: CompleteNormKwargs = {
-    "eps": 1e-5,
-    "momentum": 0.1,
-    "affine": True,
-    "track_running_stats": True,
-    "num_groups": 1,
-}
-
-NormalizationType: TypeAlias = Literal["batch", "group"]
+ResNetNormalizationType: TypeAlias = Literal["batch", "group"]
 
 
 class ResNetBasicBlock(SequentialGrowingModel):
@@ -88,7 +59,7 @@ class ResNetBasicBlock(SequentialGrowingModel):
     use_preactivation : bool
         If True, use full pre-activation ResNet (BN-ReLU before conv).
         If False, use classical ResNet (conv-BN-ReLU).
-    normalization : NormalizationType | None
+    normalization : ResNetNormalizationType | None
         Normalization layer to use. Supported values are ``"batch"``,
         ``"group"``, and ``None``.
     normalization_kwargs : NormKwargs | None
@@ -116,7 +87,7 @@ class ResNetBasicBlock(SequentialGrowingModel):
         small_inputs: bool = False,
         inplanes: int = 64,
         use_preactivation: bool = True,
-        normalization: NormalizationType | None = "batch",
+        normalization: ResNetNormalizationType | None = "batch",
         normalization_kwargs: NormKwargs | None = None,
         growing_conv_type: type[Conv2dGrowingModule] = RestrictedConv2dGrowingModule,
     ) -> None:
@@ -129,7 +100,7 @@ class ResNetBasicBlock(SequentialGrowingModel):
         self.inplanes = inplanes
         self.input_block_kernel_size = input_block_kernel_size
         self.output_block_kernel_size = output_block_kernel_size
-        self.normalization: NormalizationType | None = self._validate_normalization(
+        self.normalization: ResNetNormalizationType | None = self._validate_normalization(
             normalization
         )
         self.normalization_kwargs: CompleteNormKwargs = base_norm_kwargs.copy()
@@ -180,18 +151,18 @@ class ResNetBasicBlock(SequentialGrowingModel):
 
     @staticmethod
     def _validate_normalization(
-        normalization: NormalizationType | None,
-    ) -> NormalizationType | None:
+        normalization: ResNetNormalizationType | None,
+    ) -> ResNetNormalizationType | None:
         """Validate and normalize the normalization configuration.
 
         Parameters
         ----------
-        normalization : NormalizationType | None
+        normalization : ResNetNormalizationType | None
             Requested normalization configuration.
 
         Returns
         -------
-        NormalizationType | None
+        ResNetNormalizationType | None
             The validated normalization name.
 
         Raises
@@ -648,7 +619,7 @@ def init_full_resnet_structure(
     inplanes: int = 64,
     nb_stages: int = 4,
     use_preactivation: bool = True,
-    normalization: NormalizationType | None = "batch",
+    normalization: ResNetNormalizationType | None = "batch",
     normalization_kwargs: NormKwargs | None = None,
     growing_conv_type: type[Conv2dGrowingModule] = RestrictedConv2dGrowingModule,
 ) -> ResNetBasicBlock:
@@ -701,7 +672,7 @@ def init_full_resnet_structure(
     use_preactivation : bool
         If True, use full pre-activation ResNet (BN-ReLU before conv).
         If False, use classical ResNet (conv-BN-ReLU).
-    normalization : NormalizationType | None
+    normalization : ResNetNormalizationType | None
         Normalization layer to use. Supported values are ``"batch"``,
         ``"group"``, and ``None``.
     normalization_kwargs : NormKwargs | None

--- a/src/gromo/containers/vgg.py
+++ b/src/gromo/containers/vgg.py
@@ -1,8 +1,7 @@
-from __future__ import annotations
-
+from collections.abc import Callable
 from copy import deepcopy
 from math import ceil, prod
-from typing import Callable, Literal, TypeAlias, TypedDict, Union, cast
+from typing import Literal, TypeAlias, TypedDict, cast
 
 import torch
 import torch.nn as nn
@@ -168,8 +167,8 @@ class VGG(SequentialGrowingModel):
 
     def __init__(
         self,
-        cfg: list[Union[str, int]],
-        target_cfg: list[Union[str, int]] | None = None,
+        cfg: list[str | int],
+        target_cfg: list[str | int] | None = None,
         in_features: int = 3,
         activation: nn.Module = nn.ReLU(inplace=True),
         normalization: NormalizationType | None = "batch",
@@ -721,8 +720,8 @@ def init_full_vgg_structure(
                 else target_stage_hidden
             )
 
-    cfg: list[Union[str, int]] = []
-    target_cfg: list[Union[str, int]] = []
+    cfg: list[str | int] = []
+    target_cfg: list[str | int] = []
     for stage_hidden in hidden_channels_per_block:
         cfg.extend(stage_hidden)
         cfg.append("M")

--- a/src/gromo/containers/vgg.py
+++ b/src/gromo/containers/vgg.py
@@ -196,6 +196,14 @@ class VGG(SequentialGrowingModel):
     growing_conv_type : type[Conv2dGrowingModule]
         Type of convolutional growing module to use
         (e.g. ``RestrictedConv2dGrowingModule``, ``FullConv2dGrowingModule``).
+
+    Raises
+    ------
+    ValueError
+        If ``number_of_fc_layers`` is not positive, ``fc_layer_width`` is not
+        positive, ``initial_fc_layer_width`` is not positive,
+        ``normalization="layer"`` and ``input_spatial_shape`` is ``None``,
+        or ``target_cfg`` does not match the pooling structure of ``cfg``.
     """
 
     def __init__(

--- a/src/gromo/containers/vgg.py
+++ b/src/gromo/containers/vgg.py
@@ -604,7 +604,10 @@ def init_full_vgg_structure(
     """
     if isinstance(input_shape, torch.Size):
         input_shape = tuple(input_shape)  # type: ignore[assignment]
-        assert len(input_shape) == 3, "input_shape must be a tuple of (C, H, W)"
+    if len(input_shape) != 3:
+        raise ValueError(
+            f"input_shape must be a sequence of length 3 (C, H, W), got {input_shape}."
+        )
     if in_features is None:
         in_features = input_shape[0]
 

--- a/src/gromo/containers/vgg.py
+++ b/src/gromo/containers/vgg.py
@@ -20,7 +20,15 @@ from gromo.modules.linear_growing_module import LinearGrowingModule
 
 
 class NormKwargs(TypedDict, total=False):
-    """Optional normalization configuration."""
+    """Optional normalization configuration.
+
+    This is a superset of all normalization keyword arguments.
+    Each normalization type uses only the relevant keys:
+
+    - ``"batch"``: ``eps``, ``momentum``, ``affine``, ``track_running_stats``
+    - ``"group"``: ``num_groups``, ``eps``, ``affine``
+    - ``"layer"``: ``eps``, ``elementwise_affine``, ``bias``
+    """
 
     # BatchNorm keys
     eps: float
@@ -34,46 +42,24 @@ class NormKwargs(TypedDict, total=False):
     bias: bool
 
 
-class CompleteBatchNormKwargs(TypedDict):
-    """Complete batch-normalization configuration."""
+class CompleteNormKwargs(TypedDict):
+    """Complete normalization configuration (superset of all norm types)."""
 
     eps: float
     momentum: float
     affine: bool
     track_running_stats: bool
-
-
-class CompleteGroupNormKwargs(TypedDict):
-    """Complete group-normalization configuration."""
-
     num_groups: int
-    eps: float
-    affine: bool
-
-
-class CompleteLayerNormKwargs(TypedDict):
-    """Complete layer-normalization configuration."""
-
-    eps: float
     elementwise_affine: bool
     bias: bool
 
 
-base_batch_norm_kwargs: CompleteBatchNormKwargs = {
+base_norm_kwargs: CompleteNormKwargs = {
     "eps": 1e-5,
     "momentum": 0.1,
     "affine": True,
     "track_running_stats": True,
-}
-
-base_group_norm_kwargs: CompleteGroupNormKwargs = {
-    "num_groups": 32,
-    "eps": 1e-5,
-    "affine": True,
-}
-
-base_layer_norm_kwargs: CompleteLayerNormKwargs = {
-    "eps": 1e-5,
+    "num_groups": 1,
     "elementwise_affine": True,
     "bias": True,
 }
@@ -199,20 +185,9 @@ class VGG(SequentialGrowingModel):
         self.normalization: NormalizationType | None = self._validate_normalization(
             normalization
         )
-        self.batch_norm_kwargs: CompleteBatchNormKwargs = base_batch_norm_kwargs.copy()
-        self.group_norm_kwargs: CompleteGroupNormKwargs = base_group_norm_kwargs.copy()
-        self.layer_norm_kwargs: CompleteLayerNormKwargs = base_layer_norm_kwargs.copy()
+        self.normalization_kwargs: CompleteNormKwargs = base_norm_kwargs.copy()
         if normalization_kwargs is not None:
-            if self.normalization == "batch":
-                self._update_batch_norm_kwargs(normalization_kwargs)
-            elif self.normalization == "group":
-                self._update_group_norm_kwargs(normalization_kwargs)
-            elif self.normalization == "layer":
-                self._update_layer_norm_kwargs(normalization_kwargs)
-            else:
-                raise ValueError(
-                    "normalization_kwargs cannot be provided when normalization is None."
-                )
+            self._update_normalization_kwargs(normalization_kwargs)
 
         self.growing_conv_type = growing_conv_type
         self.initial_fc_layer_width = (
@@ -419,32 +394,8 @@ class VGG(SequentialGrowingModel):
             f"got {normalization!r}."
         )
 
-    def _update_batch_norm_kwargs(self, normalization_kwargs: NormKwargs) -> None:
-        for key, value in normalization_kwargs.items():
-            if key not in self.batch_norm_kwargs:
-                raise ValueError(
-                    f"Unsupported BatchNorm kwarg {key!r}. "
-                    "Allowed keys: eps, momentum, affine, track_running_stats."
-                )
-            self.batch_norm_kwargs[key] = value  # type: ignore[index]
-
-    def _update_group_norm_kwargs(self, normalization_kwargs: NormKwargs) -> None:
-        for key, value in normalization_kwargs.items():
-            if key not in self.group_norm_kwargs:
-                raise ValueError(
-                    f"Unsupported GroupNorm kwarg {key!r}. "
-                    "Allowed keys: num_groups, eps, affine."
-                )
-            self.group_norm_kwargs[key] = value  # type: ignore[index]
-
-    def _update_layer_norm_kwargs(self, normalization_kwargs: NormKwargs) -> None:
-        for key, value in normalization_kwargs.items():
-            if key not in self.layer_norm_kwargs:
-                raise ValueError(
-                    f"Unsupported LayerNorm kwarg {key!r}. "
-                    "Allowed keys: eps, elementwise_affine, bias."
-                )
-            self.layer_norm_kwargs[key] = value  # type: ignore[index]
+    def _update_normalization_kwargs(self, normalization_kwargs: NormKwargs) -> None:
+        self.normalization_kwargs.update(normalization_kwargs)
 
     def _make_activation(self) -> nn.Module:
         return deepcopy(self.activation)
@@ -459,18 +410,18 @@ class VGG(SequentialGrowingModel):
         if self.normalization == "batch":
             return GrowingBatchNorm2d(
                 num_channels,
-                eps=self.batch_norm_kwargs["eps"],
-                momentum=self.batch_norm_kwargs["momentum"],
-                affine=self.batch_norm_kwargs["affine"],
-                track_running_stats=self.batch_norm_kwargs["track_running_stats"],
+                eps=self.normalization_kwargs["eps"],
+                momentum=self.normalization_kwargs["momentum"],
+                affine=self.normalization_kwargs["affine"],
+                track_running_stats=self.normalization_kwargs["track_running_stats"],
                 device=self.device,
             )
         if self.normalization == "group":
             return GrowingGroupNorm(
-                num_groups=self.group_norm_kwargs["num_groups"],
+                num_groups=self.normalization_kwargs["num_groups"],
                 num_channels=num_channels,
-                eps=self.group_norm_kwargs["eps"],
-                affine=self.group_norm_kwargs["affine"],
+                eps=self.normalization_kwargs["eps"],
+                affine=self.normalization_kwargs["affine"],
                 device=self.device,
             )
         if self.normalization == "layer":
@@ -480,9 +431,9 @@ class VGG(SequentialGrowingModel):
                 )
             return GrowingLayerNorm(
                 [num_channels, *spatial_shape],
-                eps=self.layer_norm_kwargs["eps"],
-                elementwise_affine=self.layer_norm_kwargs["elementwise_affine"],
-                bias=self.layer_norm_kwargs["bias"],
+                eps=self.normalization_kwargs["eps"],
+                elementwise_affine=self.normalization_kwargs["elementwise_affine"],
+                bias=self.normalization_kwargs["bias"],
                 device=self.device,
             )
         raise AssertionError("Normalization should have been validated before use.")
@@ -509,9 +460,11 @@ def _reduce_growing_conv_widths(
     if reduction_factor is None:
         return stage_hidden_per_block
     return tuple(
-        stage_width
-        if block_idx == len(stage_hidden_per_block) - 1
-        else ceil(stage_width * reduction_factor)
+        (
+            stage_width
+            if block_idx == len(stage_hidden_per_block) - 1
+            else ceil(stage_width * reduction_factor)
+        )
         for block_idx, stage_width in enumerate(stage_hidden_per_block)
     )
 

--- a/src/gromo/containers/vgg.py
+++ b/src/gromo/containers/vgg.py
@@ -1,0 +1,814 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from math import ceil, prod
+from typing import Callable, Literal, TypeAlias, TypedDict, Union, cast
+
+import torch
+import torch.nn as nn
+
+from gromo.containers.sequential_growing_container import SequentialGrowingModel
+from gromo.modules.conv2d_growing_module import (
+    Conv2dGrowingModule,
+    RestrictedConv2dGrowingModule,
+)
+from gromo.modules.growing_normalisation import (
+    GrowingBatchNorm2d,
+    GrowingGroupNorm,
+    GrowingLayerNorm,
+)
+from gromo.modules.linear_growing_module import LinearGrowingModule
+
+
+class NormKwargs(TypedDict, total=False):
+    """Optional normalization configuration."""
+
+    # BatchNorm keys
+    eps: float
+    momentum: float
+    affine: bool
+    track_running_stats: bool
+    # GroupNorm key
+    num_groups: int
+    # LayerNorm keys
+    elementwise_affine: bool
+    bias: bool
+
+
+class CompleteBatchNormKwargs(TypedDict):
+    """Complete batch-normalization configuration."""
+
+    eps: float
+    momentum: float
+    affine: bool
+    track_running_stats: bool
+
+
+class CompleteGroupNormKwargs(TypedDict):
+    """Complete group-normalization configuration."""
+
+    num_groups: int
+    eps: float
+    affine: bool
+
+
+class CompleteLayerNormKwargs(TypedDict):
+    """Complete layer-normalization configuration."""
+
+    eps: float
+    elementwise_affine: bool
+    bias: bool
+
+
+base_batch_norm_kwargs: CompleteBatchNormKwargs = {
+    "eps": 1e-5,
+    "momentum": 0.1,
+    "affine": True,
+    "track_running_stats": True,
+}
+
+base_group_norm_kwargs: CompleteGroupNormKwargs = {
+    "num_groups": 32,
+    "eps": 1e-5,
+    "affine": True,
+}
+
+base_layer_norm_kwargs: CompleteLayerNormKwargs = {
+    "eps": 1e-5,
+    "elementwise_affine": True,
+    "bias": True,
+}
+
+NormalizationType: TypeAlias = Literal["batch", "group", "layer"]
+
+
+class _VGGStageBlock(nn.Module):
+    """VGG stage made of consecutive convolutions sharing one target stage width."""
+
+    def __init__(
+        self,
+        stage_channels: tuple[int, ...],
+        target_stage_channels: tuple[int, ...],
+        *,
+        in_channels: int,
+        spatial_shape: tuple[int, int] | None,
+        build_post_conv_layers: Callable[[int, tuple[int, int] | None], nn.Module],
+        growing_conv_type: type[Conv2dGrowingModule],
+        device: torch.device | str | None,
+        name: str,
+    ) -> None:
+        super().__init__()
+        if len(stage_channels) != len(target_stage_channels):
+            raise ValueError(
+                "stage_channels and target_stage_channels must have the same length."
+            )
+        if len(stage_channels) == 0:
+            raise ValueError("A VGG stage must contain at least one convolution.")
+
+        self.convs = nn.Sequential()
+        self.growing_modules: list[Conv2dGrowingModule] = []
+        self.growable_layers: list[Conv2dGrowingModule] = []
+
+        previous_growing_layer: Conv2dGrowingModule | None = None
+        current_in_channels = in_channels
+        stage_target_out_channels = target_stage_channels[0]
+        for layer_index, (out_channels, _) in enumerate(
+            zip(stage_channels, target_stage_channels, strict=True)
+        ):
+            is_first_conv = layer_index == 0
+            post_layer_function = build_post_conv_layers(
+                out_channels,
+                spatial_shape,
+            )
+            target_in_channels = None if is_first_conv else stage_target_out_channels
+            conv = growing_conv_type(
+                in_channels=current_in_channels,
+                out_channels=out_channels,
+                kernel_size=3,
+                padding=1,
+                use_bias=True,
+                previous_module=None if is_first_conv else previous_growing_layer,
+                post_layer_function=post_layer_function,
+                allow_growing=not is_first_conv,
+                target_in_channels=target_in_channels,
+                name=f"{name}.convs.{layer_index}.conv",
+                device=device,
+            )
+            self.convs.append(conv)
+            self.growing_modules.append(conv)
+            if (
+                not is_first_conv
+                and target_in_channels is not None
+                and target_in_channels > conv.in_channels
+            ):
+                self.growable_layers.append(conv)
+            previous_growing_layer = conv
+            current_in_channels = out_channels
+
+        self.out_channels = current_in_channels
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        for module in self.convs:
+            x = module(x)
+        return x
+
+    def extended_forward(
+        self,
+        x: torch.Tensor,
+        x_ext: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        for module in self.convs:
+            x, x_ext = module.extended_forward(x, x_ext)
+        return x, x_ext
+
+
+class VGG(SequentialGrowingModel):
+    """Growable VGG backbone with torchvision-aligned classifier."""
+
+    def __init__(
+        self,
+        cfg: list[Union[str, int]],
+        target_cfg: list[Union[str, int]] | None = None,
+        in_features: int = 3,
+        activation: nn.Module = nn.ReLU(inplace=True),
+        normalization: NormalizationType | None = "batch",
+        normalization_kwargs: NormKwargs | None = None,
+        num_classes: int = 1000,
+        init_weights: bool = True,
+        dropout: float = 0.5,
+        number_of_fc_layers: int = 3,
+        fc_layer_width: int = 4096,
+        initial_fc_layer_width: int | None = None,
+        input_spatial_shape: tuple[int, int] | None = None,
+        device: torch.device | str | None = None,
+        growing_conv_type: type[Conv2dGrowingModule] = RestrictedConv2dGrowingModule,
+    ) -> None:
+        super().__init__(in_features=in_features, out_features=num_classes, device=device)
+        if number_of_fc_layers <= 0:
+            raise ValueError(
+                f"number_of_fc_layers must be > 0, got {number_of_fc_layers}."
+            )
+        if fc_layer_width <= 0:
+            raise ValueError(f"fc_layer_width must be > 0, got {fc_layer_width}.")
+        if initial_fc_layer_width is not None and initial_fc_layer_width <= 0:
+            raise ValueError(
+                f"initial_fc_layer_width must be > 0, got {initial_fc_layer_width}."
+            )
+
+        self.activation = activation.to(device)
+        self.normalization: NormalizationType | None = self._validate_normalization(
+            normalization
+        )
+        self.batch_norm_kwargs: CompleteBatchNormKwargs = base_batch_norm_kwargs.copy()
+        self.group_norm_kwargs: CompleteGroupNormKwargs = base_group_norm_kwargs.copy()
+        self.layer_norm_kwargs: CompleteLayerNormKwargs = base_layer_norm_kwargs.copy()
+        if normalization_kwargs is not None:
+            if self.normalization == "batch":
+                self._update_batch_norm_kwargs(normalization_kwargs)
+            elif self.normalization == "group":
+                self._update_group_norm_kwargs(normalization_kwargs)
+            elif self.normalization == "layer":
+                self._update_layer_norm_kwargs(normalization_kwargs)
+            else:
+                raise ValueError(
+                    "normalization_kwargs cannot be provided when normalization is None."
+                )
+
+        self.growing_conv_type = growing_conv_type
+        self.initial_fc_layer_width = (
+            fc_layer_width if initial_fc_layer_width is None else initial_fc_layer_width
+        )
+        self.input_spatial_shape = input_spatial_shape
+        if self.normalization == "layer" and self.input_spatial_shape is None:
+            raise ValueError(
+                "input_spatial_shape must be provided when normalization='layer'."
+            )
+
+        current_spatial_shape = self.input_spatial_shape
+
+        self.features = nn.Sequential()
+        self.flatten = nn.Flatten(1)
+        self.classifier = nn.Sequential()
+        if target_cfg is None:
+            target_cfg = cfg
+
+        feature_stages: list[tuple[list[int], list[int], bool]] = []
+        current_stage: list[int] = []
+        current_target_stage: list[int] = []
+        for value, target_value in zip(cfg, target_cfg, strict=True):
+            if value == "M":
+                if target_value != "M":
+                    raise ValueError(
+                        "target_cfg must match cfg pooling structure exactly."
+                    )
+                if current_stage:
+                    feature_stages.append((current_stage, current_target_stage, True))
+                    current_stage = []
+                    current_target_stage = []
+                continue
+            current_stage.append(cast("int", value))
+            current_target_stage.append(cast("int", target_value))
+        if current_stage:
+            feature_stages.append((current_stage, current_target_stage, False))
+
+        self.stage_blocks = nn.ModuleList()
+        self._feature_growing_modules: list[Conv2dGrowingModule] = []
+        self._classifier_growing_modules: list[LinearGrowingModule] = []
+        growable_layers: list[Conv2dGrowingModule | LinearGrowingModule] = []
+
+        in_channels = in_features
+        current_stage_target_out_channels = in_features
+        feature_module_index = 0
+        for stage_index, (stage_channels, target_stage_channels, has_pool) in enumerate(
+            feature_stages
+        ):
+            stage_block = _VGGStageBlock(
+                tuple(stage_channels),
+                tuple(target_stage_channels),
+                in_channels=in_channels,
+                spatial_shape=current_spatial_shape,
+                build_post_conv_layers=self._build_post_conv_layers,
+                growing_conv_type=growing_conv_type,
+                device=self.device,
+                name=f"features.{feature_module_index}",
+            )
+            self.stage_blocks.append(stage_block)
+            self.features.append(stage_block)
+            feature_module_index += 1
+            self._feature_growing_modules.extend(stage_block.growing_modules)
+            growable_layers.extend(stage_block.growable_layers)
+            in_channels = stage_block.out_channels
+            current_stage_target_out_channels = target_stage_channels[0]
+            if has_pool:
+                self.features.append(nn.MaxPool2d(kernel_size=2, stride=2))
+                feature_module_index += 1
+                if current_spatial_shape is not None:
+                    current_spatial_shape = (
+                        current_spatial_shape[0] // 2,
+                        current_spatial_shape[1] // 2,
+                    )
+
+        self.final_spatial_shape = (
+            (7, 7) if current_spatial_shape is None else current_spatial_shape
+        )
+        self.avgpool = nn.AdaptiveAvgPool2d(self.final_spatial_shape)
+
+        classifier_growing_layers: list[LinearGrowingModule] = []
+        previous_classifier_layer = (
+            self._feature_growing_modules[-1] if self._feature_growing_modules else None
+        )
+        classifier_target_in_features = current_stage_target_out_channels * prod(
+            self.final_spatial_shape
+        )
+        classifier_current_in_features = in_channels * prod(self.final_spatial_shape)
+        for classifier_layer_idx in range(number_of_fc_layers):
+            is_last_layer = classifier_layer_idx == number_of_fc_layers - 1
+            layer_in_features = classifier_current_in_features
+            target_in_features = (
+                classifier_target_in_features
+                if classifier_layer_idx == 0
+                else fc_layer_width
+            )
+            layer_out_features = (
+                num_classes if is_last_layer else self.initial_fc_layer_width
+            )
+            post_layer_function: nn.Module = (
+                nn.Identity() if is_last_layer else self._make_activation()
+            )
+
+            linear = LinearGrowingModule(
+                in_features=layer_in_features,
+                out_features=layer_out_features,
+                use_bias=True,
+                previous_module=previous_classifier_layer,
+                post_layer_function=post_layer_function,
+                allow_growing=(
+                    classifier_layer_idx > 0 and target_in_features > layer_in_features
+                ),
+                name=f"classifier.{3 * classifier_layer_idx}",
+                device=self.device,
+                target_in_features=target_in_features,
+            )
+            self.classifier.append(linear)
+            self._classifier_growing_modules.append(linear)
+            if classifier_layer_idx > 0 and target_in_features > layer_in_features:
+                classifier_growing_layers.append(linear)
+            previous_classifier_layer = linear
+
+            if not is_last_layer:
+                self.classifier.append(nn.Dropout(p=dropout))
+                classifier_current_in_features = self.initial_fc_layer_width
+
+        growable_layers.extend(classifier_growing_layers)
+        self._growable_layers = list(growable_layers)
+        self.set_growing_layers(scheduling_method="all")
+
+        if init_weights:
+            self._initialize_weights()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """Run the standard VGG forward pass."""
+        for module in self.features:
+            x = module(x)
+        x = self.avgpool(x)
+        x = self.flatten(x)
+        for module in self.classifier:
+            x = module(x)
+        return x
+
+    def extended_forward(
+        self,
+        x: torch.Tensor,
+        mask: dict | None = None,  # noqa: ARG002
+    ) -> torch.Tensor:
+        """Run the forward pass while tracking the growth extension branch."""
+        x_ext = None
+        for module in self.features:
+            if isinstance(module, (_VGGStageBlock, Conv2dGrowingModule)):
+                x, x_ext = module.extended_forward(x, x_ext)
+            else:
+                x = module(x)
+                if x_ext is not None:
+                    x_ext = module(x_ext)
+        x = self.avgpool(x)
+        if x_ext is not None:
+            x_ext = self.avgpool(x_ext)
+        x = self.flatten(x)
+        if x_ext is not None:
+            x_ext = self.flatten(x_ext)
+        for module in self.classifier:
+            if isinstance(module, LinearGrowingModule):
+                x, x_ext = module.extended_forward(x, x_ext)
+            else:
+                x = module(x)
+                if x_ext is not None:
+                    x_ext = module(x_ext)
+        return x
+
+    def _initialize_weights(self) -> None:
+        for module in self.modules():
+            if isinstance(module, Conv2dGrowingModule):
+                nn.init.kaiming_normal_(
+                    module.weight,
+                    mode="fan_out",
+                    nonlinearity="relu",
+                )
+                if module.bias is not None:
+                    nn.init.constant_(module.bias, 0)
+            elif isinstance(
+                module, (GrowingBatchNorm2d, GrowingGroupNorm, GrowingLayerNorm)
+            ):
+                if module.weight is not None:
+                    nn.init.constant_(module.weight, 1)
+                if module.bias is not None:
+                    nn.init.constant_(module.bias, 0)
+            elif isinstance(module, LinearGrowingModule):
+                nn.init.normal_(module.weight, 0, 0.01)
+                nn.init.constant_(module.bias, 0)
+
+    @staticmethod
+    def _validate_normalization(
+        normalization: NormalizationType | None,
+    ) -> NormalizationType | None:
+        if normalization is None:
+            return None
+        if normalization in {"batch", "group", "layer"}:
+            return normalization
+        raise ValueError(
+            "normalization must be 'batch', 'group', 'layer' or None, "
+            f"got {normalization!r}."
+        )
+
+    def _update_batch_norm_kwargs(self, normalization_kwargs: NormKwargs) -> None:
+        for key, value in normalization_kwargs.items():
+            if key not in self.batch_norm_kwargs:
+                raise ValueError(
+                    f"Unsupported BatchNorm kwarg {key!r}. "
+                    "Allowed keys: eps, momentum, affine, track_running_stats."
+                )
+            self.batch_norm_kwargs[key] = value  # type: ignore[index]
+
+    def _update_group_norm_kwargs(self, normalization_kwargs: NormKwargs) -> None:
+        for key, value in normalization_kwargs.items():
+            if key not in self.group_norm_kwargs:
+                raise ValueError(
+                    f"Unsupported GroupNorm kwarg {key!r}. "
+                    "Allowed keys: num_groups, eps, affine."
+                )
+            self.group_norm_kwargs[key] = value  # type: ignore[index]
+
+    def _update_layer_norm_kwargs(self, normalization_kwargs: NormKwargs) -> None:
+        for key, value in normalization_kwargs.items():
+            if key not in self.layer_norm_kwargs:
+                raise ValueError(
+                    f"Unsupported LayerNorm kwarg {key!r}. "
+                    "Allowed keys: eps, elementwise_affine, bias."
+                )
+            self.layer_norm_kwargs[key] = value  # type: ignore[index]
+
+    def _make_activation(self) -> nn.Module:
+        return deepcopy(self.activation)
+
+    def _build_growing_normalization(
+        self,
+        num_channels: int,
+        spatial_shape: tuple[int, int] | None = None,
+    ) -> nn.Module | None:
+        if self.normalization is None:
+            return None
+        if self.normalization == "batch":
+            return GrowingBatchNorm2d(
+                num_channels,
+                eps=self.batch_norm_kwargs["eps"],
+                momentum=self.batch_norm_kwargs["momentum"],
+                affine=self.batch_norm_kwargs["affine"],
+                track_running_stats=self.batch_norm_kwargs["track_running_stats"],
+                device=self.device,
+            )
+        if self.normalization == "group":
+            return GrowingGroupNorm(
+                num_groups=self.group_norm_kwargs["num_groups"],
+                num_channels=num_channels,
+                eps=self.group_norm_kwargs["eps"],
+                affine=self.group_norm_kwargs["affine"],
+                device=self.device,
+            )
+        if self.normalization == "layer":
+            if spatial_shape is None:
+                raise ValueError(
+                    "spatial_shape must be provided when normalization='layer'."
+                )
+            return GrowingLayerNorm(
+                [num_channels, *spatial_shape],
+                eps=self.layer_norm_kwargs["eps"],
+                elementwise_affine=self.layer_norm_kwargs["elementwise_affine"],
+                bias=self.layer_norm_kwargs["bias"],
+                device=self.device,
+            )
+        raise AssertionError("Normalization should have been validated before use.")
+
+    def _build_post_conv_layers(
+        self,
+        num_channels: int,
+        spatial_shape: tuple[int, int] | None = None,
+    ) -> nn.Module:
+        normalization = self._build_growing_normalization(num_channels, spatial_shape)
+        layers: list[nn.Module] = []
+        if normalization is not None:
+            layers.append(normalization)
+        layers.append(self._make_activation())
+        if len(layers) == 1:
+            return layers[0]
+        return nn.Sequential(*layers)
+
+
+def _reduce_growing_conv_widths(
+    stage_hidden_per_block: tuple[int, ...],
+    reduction_factor: float | None,
+) -> tuple[int, ...]:
+    if reduction_factor is None:
+        return stage_hidden_per_block
+    return tuple(
+        stage_width if block_idx == 0 else ceil(stage_width * reduction_factor)
+        for block_idx, stage_width in enumerate(stage_hidden_per_block)
+    )
+
+
+def init_full_vgg_structure(
+    input_shape: tuple[int, int, int] = (3, 224, 224),
+    in_features: int | None = None,
+    out_features: int = 1000,
+    device: torch.device | str | None = None,
+    activation: nn.Module = nn.ReLU(inplace=True),
+    normalization: NormalizationType | None = "batch",
+    normalization_kwargs: NormKwargs | None = None,
+    hidden_channels: tuple[int | tuple[int, ...], ...] | None = None,
+    number_of_conv_per_stage: int | tuple[int, ...] = (1, 1, 2, 2, 2),
+    nb_stages: int = 5,
+    init_weights: bool = True,
+    dropout: float = 0.5,
+    number_of_fc_layers: int = 3,
+    fc_layer_width: int = 4096,
+    reduction_factor: float | None = 1 / 32,
+    growing_conv_type: type[Conv2dGrowingModule] = RestrictedConv2dGrowingModule,
+) -> VGG:
+    """Initialize a customizable VGG-style model with full stage/block control.
+
+    Parameters
+    ----------
+    input_shape : tuple[int, int, int]
+        Shape of the input tensor (C, H, W). Used to infer in_features when
+        ``in_features`` is not provided.
+    in_features : int | None
+        Number of input channels. If None, inferred from ``input_shape``.
+    out_features : int
+        Number of output classes.
+    device : torch.device | str | None
+        Device to run the model on.
+    activation : nn.Module
+        Activation function to use after each normalized convolution/linear
+        block in the feature extractor and classifier hidden layers.
+    normalization : NormalizationType | None
+        Normalization layer to use. Supported values are ``"batch"``,
+        ``"group"``, ``"layer"``, and ``None``.
+    normalization_kwargs : NormKwargs | None
+        Additional keyword arguments passed to the selected normalization layer.
+        Supported keys are:
+        ``eps``, ``momentum``, ``affine``, ``track_running_stats`` for batch norm;
+        ``num_groups``, ``eps``, ``affine`` for group norm;
+        ``eps``, ``elementwise_affine``, ``bias`` for layer norm.
+    hidden_channels : tuple[int | tuple[int, ...], ...] | None
+        Explicit channels per stage/block. If provided, each stage entry can be:
+        - int: same width for all blocks in the stage
+        - tuple[int, ...]: explicit width per block in the stage
+    number_of_conv_per_stage : int | tuple[int, ...]
+        Number of convolutions in each stage. If an int is provided, the
+        same value is used across all stages.
+    nb_stages : int
+        Number of convolution stages.
+    init_weights : bool
+        If True, initialize model weights with VGG-style initialization.
+    dropout : float
+        Dropout probability used in the classifier.
+    number_of_fc_layers : int
+        Number of fully connected layers in the classifier.
+    fc_layer_width : int
+        Target hidden width of fully connected classifier layers.
+    reduction_factor : float | None
+        Factor used to initialize layers with ``allow_growing=True`` from
+        their target width. For convolutions, this applies to layers that are
+        not the first convolution of a stage. For the classifier, this applies
+        to growable hidden fully connected layers. If ``None``, keep the target
+        width unchanged for those layers.
+    growing_conv_type : type[Conv2dGrowingModule]
+        Convolution growing module type to instantiate.
+
+    Returns
+    -------
+    VGG
+        The initialized VGG model.
+
+    Raises
+    ------
+    TypeError
+        If classifier, reduction, stage-convolution, or hidden-channel
+        arguments have invalid types.
+    ValueError
+        If classifier sizes are not strictly positive, ``reduction_factor`` is
+        out of bounds, stage/block shapes are inconsistent, normalization
+        arguments are invalid, or normalization-specific requirements are not
+        met.
+    """
+    if isinstance(input_shape, torch.Size):
+        input_shape = tuple(input_shape)  # type: ignore[assignment]
+        assert len(input_shape) == 3, "input_shape must be a tuple of (C, H, W)"
+    if in_features is None:
+        in_features = input_shape[0]
+
+    if not isinstance(number_of_fc_layers, int):
+        raise TypeError(
+            f"number_of_fc_layers must be an int, got {type(number_of_fc_layers).__name__}."
+        )
+    if number_of_fc_layers <= 0:
+        raise ValueError(f"number_of_fc_layers must be > 0, got {number_of_fc_layers}.")
+
+    if not isinstance(fc_layer_width, int):
+        raise TypeError(
+            f"fc_layer_width must be an int, got {type(fc_layer_width).__name__}."
+        )
+    if fc_layer_width <= 0:
+        raise ValueError(f"fc_layer_width must be > 0, got {fc_layer_width}.")
+    if reduction_factor is not None and not isinstance(reduction_factor, (int, float)):
+        raise TypeError(
+            "reduction_factor must be a float, int, or None, "
+            f"got {type(reduction_factor).__name__}."
+        )
+    if reduction_factor is not None and not (0 < float(reduction_factor) <= 1):
+        raise ValueError(
+            "reduction_factor must satisfy 0 < reduction_factor <= 1, "
+            f"got {reduction_factor}."
+        )
+
+    if isinstance(number_of_conv_per_stage, int):
+        conv_per_stage: tuple[int, ...] = (number_of_conv_per_stage,) * nb_stages
+    elif (
+        isinstance(number_of_conv_per_stage, (list, tuple))
+        and len(number_of_conv_per_stage) == nb_stages
+    ):
+        conv_per_stage = tuple(number_of_conv_per_stage)
+    else:
+        raise TypeError(
+            f"number_of_conv_per_stage must be an int or a tuple of {nb_stages} ints."
+        )
+
+    for stage_idx, num_conv in enumerate(conv_per_stage):
+        if not isinstance(num_conv, int):
+            raise TypeError(
+                f"Stage {stage_idx}: number_of_conv_per_stage must contain ints, "
+                f"got {type(num_conv).__name__}."
+            )
+        if num_conv <= 0:
+            raise ValueError(
+                f"Stage {stage_idx}: number_of_conv_per_stage must be > 0, "
+                f"got {num_conv}."
+            )
+
+    hidden_channels_per_block: list[tuple[int, ...]] = []
+    target_hidden_channels_per_block: list[tuple[int, ...]] = []
+    if hidden_channels is not None:
+        if len(hidden_channels) != nb_stages:
+            raise ValueError(
+                f"hidden_channels must have {nb_stages} elements (one per stage), "
+                f"but got {len(hidden_channels)}."
+            )
+        for stage_idx, stage_hidden in enumerate(hidden_channels):
+            num_conv = conv_per_stage[stage_idx]
+            if isinstance(stage_hidden, int):
+                stage_hidden_per_block = (stage_hidden,) * num_conv
+            elif isinstance(stage_hidden, (list, tuple)):
+                if len(stage_hidden) != num_conv:
+                    raise ValueError(
+                        f"Stage {stage_idx}: hidden_channels has {len(stage_hidden)} "
+                        f"elements but number_of_conv_per_stage is {num_conv}."
+                    )
+                stage_hidden_per_block = tuple(stage_hidden)
+            else:
+                raise TypeError(
+                    f"Stage {stage_idx}: hidden_channels element must be int or tuple, "
+                    f"got {type(stage_hidden).__name__}."
+                )
+
+            for block_idx, stage_width in enumerate(stage_hidden_per_block):
+                if not isinstance(stage_width, int):
+                    raise TypeError(
+                        f"Stage {stage_idx} Block {block_idx}: hidden_channels must "
+                        f"contain ints, got {type(stage_width).__name__}."
+                    )
+                if stage_width <= 0:
+                    raise ValueError(
+                        f"Stage {stage_idx} Block {block_idx}: hidden_channels must "
+                        f"be > 0, got {stage_width}."
+                    )
+
+            target_hidden_channels_per_block.append(stage_hidden_per_block)
+            hidden_channels_per_block.append(
+                _reduce_growing_conv_widths(
+                    stage_hidden_per_block, float(reduction_factor)
+                )
+                if reduction_factor is not None
+                else stage_hidden_per_block
+            )
+    else:
+        for stage_idx in range(nb_stages):
+            num_conv = conv_per_stage[stage_idx]
+            stage_hidden = 64 * min(2**stage_idx, 8)
+            if stage_hidden <= 0:
+                raise ValueError(
+                    f"Stage {stage_idx}: computed hidden width must be > 0, "
+                    f"got {stage_hidden}."
+                )
+            target_stage_hidden = (stage_hidden,) * num_conv
+            target_hidden_channels_per_block.append(target_stage_hidden)
+            hidden_channels_per_block.append(
+                _reduce_growing_conv_widths(target_stage_hidden, float(reduction_factor))
+                if reduction_factor is not None
+                else target_stage_hidden
+            )
+
+    cfg: list[Union[str, int]] = []
+    target_cfg: list[Union[str, int]] = []
+    for stage_hidden in hidden_channels_per_block:
+        cfg.extend(stage_hidden)
+        cfg.append("M")
+    for target_stage_hidden in target_hidden_channels_per_block:
+        target_cfg.extend(target_stage_hidden)
+        target_cfg.append("M")
+
+    return VGG(
+        cfg=cfg,
+        target_cfg=target_cfg,
+        in_features=in_features,
+        activation=activation,
+        normalization=normalization,
+        normalization_kwargs=normalization_kwargs,
+        num_classes=out_features,
+        init_weights=init_weights,
+        dropout=dropout,
+        number_of_fc_layers=number_of_fc_layers,
+        fc_layer_width=fc_layer_width,
+        initial_fc_layer_width=(
+            ceil(fc_layer_width * float(reduction_factor))
+            if reduction_factor is not None
+            else fc_layer_width
+        ),
+        input_spatial_shape=input_shape[1:],
+        device=device,
+        growing_conv_type=growing_conv_type,
+    )
+
+
+if __name__ == "__main__":
+    try:
+        from torchvision.models import vgg11
+    except ImportError:
+        print("torchvision is not installed; skipping VGG parity smoke test.")
+    else:
+        torch.manual_seed(0)
+        model = init_full_vgg_structure(
+            input_shape=(3, 224, 224),
+            out_features=1000,
+            normalization=None,
+            number_of_conv_per_stage=(1, 1, 2, 2, 2),
+            hidden_channels=(64, 128, 256, 512, 512),
+            number_of_fc_layers=3,
+            fc_layer_width=4096,
+            reduction_factor=None,
+            device=torch.device("cpu"),
+        )
+        reference = vgg11(weights=None)
+
+        reference_convs = [
+            module for module in reference.features if isinstance(module, nn.Conv2d)
+        ]
+        assert len(reference_convs) == len(model._feature_growing_modules)
+        for ref_conv, model_conv in zip(
+            reference_convs, model._feature_growing_modules, strict=True
+        ):
+            with torch.no_grad():
+                model_conv.weight.copy_(ref_conv.weight)
+                assert model_conv.bias is not None
+                assert ref_conv.bias is not None
+                model_conv.bias.copy_(ref_conv.bias)
+
+        reference_linears = [
+            module for module in reference.classifier if isinstance(module, nn.Linear)
+        ]
+        model_linears = [
+            module
+            for module in model.classifier
+            if isinstance(module, LinearGrowingModule)
+        ]
+        assert len(reference_linears) == len(model_linears)
+        for ref_linear, model_linear in zip(
+            reference_linears, model_linears, strict=True
+        ):
+            with torch.no_grad():
+                model_linear.weight.copy_(ref_linear.weight)
+                assert model_linear.bias is not None
+                assert ref_linear.bias is not None
+                model_linear.bias.copy_(ref_linear.bias)
+
+        model.eval()
+        reference.eval()
+        x = torch.randn(2, 3, 224, 224)
+        with torch.no_grad():
+            model_output = model(x)
+            reference_output = reference(x)
+
+        max_diff = torch.max(torch.abs(model_output - reference_output)).item()
+        print("torchvision VGG11 parity smoke test")
+        print(
+            f"parameter_count_match={model.number_of_parameters() == sum(p.numel() for p in reference.parameters())}"
+        )
+        print(f"output_shape={tuple(model_output.shape)}")
+        print(f"max_abs_diff={max_diff:.6e}")

--- a/src/gromo/containers/vgg.py
+++ b/src/gromo/containers/vgg.py
@@ -149,7 +149,54 @@ class _VGGStageBlock(nn.Module):
 
 
 class VGG(SequentialGrowingModel):
-    """Growable VGG backbone with torchvision-aligned classifier."""
+    """Growable VGG backbone with torchvision-aligned classifier.
+
+    Parameters
+    ----------
+    cfg : list[str | int]
+        Architecture configuration. Each integer specifies the number of output
+        channels of a convolutional layer; ``"M"`` inserts a MaxPool2d layer.
+    target_cfg : list[str | int] | None
+        Target configuration used to size the growing modules. Must share the
+        same pooling structure as ``cfg``. Defaults to ``cfg`` when ``None``.
+    in_features : int
+        Number of input channels.
+    activation : nn.Module
+        Activation function applied after each convolution.
+    normalization : NormalizationType | None
+        Normalization layer to use. Supported values are ``"batch"``,
+        ``"group"``, ``"layer"``, and ``None``.
+    normalization_kwargs : NormKwargs | None
+        Additional keyword arguments passed to normalization layers.
+        Supported keys depend on the normalization type:
+
+        - ``"batch"``: ``eps``, ``momentum``, ``affine``, ``track_running_stats``
+        - ``"group"``: ``num_groups``, ``eps``, ``affine``
+        - ``"layer"``: ``eps``, ``elementwise_affine``, ``bias``
+
+        Keys irrelevant to the chosen normalization are ignored.
+    num_classes : int
+        Number of output classes.
+    init_weights : bool
+        If ``True``, initialise weights with Kaiming normal / constant init.
+    dropout : float
+        Dropout probability applied inside the classifier.
+    number_of_fc_layers : int
+        Number of fully-connected layers in the classifier (must be > 0).
+    fc_layer_width : int
+        Width of the hidden fully-connected layers (must be > 0).
+    initial_fc_layer_width : int | None
+        Width of the first fully-connected layer. Defaults to ``fc_layer_width``
+        when ``None``.
+    input_spatial_shape : tuple[int, int] | None
+        Spatial dimensions ``(H, W)`` of the input feature maps. Required when
+        ``normalization="layer"``.
+    device : torch.device | str | None
+        Device to run the model on.
+    growing_conv_type : type[Conv2dGrowingModule]
+        Type of convolutional growing module to use
+        (e.g. ``RestrictedConv2dGrowingModule``, ``FullConv2dGrowingModule``).
+    """
 
     def __init__(
         self,

--- a/src/gromo/containers/vgg.py
+++ b/src/gromo/containers/vgg.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from copy import deepcopy
 from math import ceil, prod
-from typing import Literal, TypeAlias, TypedDict, cast
+from typing import Literal, TypeAlias, cast
 
 import torch
 import torch.nn as nn
@@ -12,59 +12,16 @@ from gromo.modules.conv2d_growing_module import (
     RestrictedConv2dGrowingModule,
 )
 from gromo.modules.growing_normalisation import (
+    CompleteNormKwargs,
     GrowingBatchNorm2d,
     GrowingGroupNorm,
-    GrowingLayerNorm,
+    NormKwargs,
+    base_norm_kwargs,
 )
 from gromo.modules.linear_growing_module import LinearGrowingModule
 
 
-class NormKwargs(TypedDict, total=False):
-    """Optional normalization configuration.
-
-    This is a superset of all normalization keyword arguments.
-    Each normalization type uses only the relevant keys:
-
-    - ``"batch"``: ``eps``, ``momentum``, ``affine``, ``track_running_stats``
-    - ``"group"``: ``num_groups``, ``eps``, ``affine``
-    - ``"layer"``: ``eps``, ``elementwise_affine``, ``bias``
-    """
-
-    # BatchNorm keys
-    eps: float
-    momentum: float
-    affine: bool
-    track_running_stats: bool
-    # GroupNorm key
-    num_groups: int
-    # LayerNorm keys
-    elementwise_affine: bool
-    bias: bool
-
-
-class CompleteNormKwargs(TypedDict):
-    """Complete normalization configuration (superset of all norm types)."""
-
-    eps: float
-    momentum: float
-    affine: bool
-    track_running_stats: bool
-    num_groups: int
-    elementwise_affine: bool
-    bias: bool
-
-
-base_norm_kwargs: CompleteNormKwargs = {
-    "eps": 1e-5,
-    "momentum": 0.1,
-    "affine": True,
-    "track_running_stats": True,
-    "num_groups": 1,
-    "elementwise_affine": True,
-    "bias": True,
-}
-
-NormalizationType: TypeAlias = Literal["batch", "group", "layer"]
+VggNormalizationType: TypeAlias = Literal["batch", "group"]
 
 
 class _VGGStageBlock(nn.Module):
@@ -76,8 +33,7 @@ class _VGGStageBlock(nn.Module):
         target_stage_channels: tuple[int, ...],
         *,
         in_channels: int,
-        spatial_shape: tuple[int, int] | None,
-        build_post_conv_layers: Callable[[int, tuple[int, int] | None], nn.Module],
+        build_post_conv_layers: Callable[[int], nn.Module],
         growing_conv_type: type[Conv2dGrowingModule],
         device: torch.device | str | None,
         name: str,
@@ -100,10 +56,7 @@ class _VGGStageBlock(nn.Module):
             zip(stage_channels, target_stage_channels, strict=True)
         ):
             is_first_conv = layer_index == 0
-            post_layer_function = build_post_conv_layers(
-                out_channels,
-                spatial_shape,
-            )
+            post_layer_function = build_post_conv_layers(out_channels)
             target_in_channels = (
                 None if is_first_conv else target_stage_channels[layer_index - 1]
             )
@@ -163,16 +116,15 @@ class VGG(SequentialGrowingModel):
         Number of input channels.
     activation : nn.Module
         Activation function applied after each convolution.
-    normalization : NormalizationType | None
+    normalization : VggNormalizationType | None
         Normalization layer to use. Supported values are ``"batch"``,
-        ``"group"``, ``"layer"``, and ``None``.
+        ``"group"``, and ``None``.
     normalization_kwargs : NormKwargs | None
         Additional keyword arguments passed to normalization layers.
         Supported keys depend on the normalization type:
 
         - ``"batch"``: ``eps``, ``momentum``, ``affine``, ``track_running_stats``
         - ``"group"``: ``num_groups``, ``eps``, ``affine``
-        - ``"layer"``: ``eps``, ``elementwise_affine``, ``bias``
 
         Keys irrelevant to the chosen normalization are ignored.
     num_classes : int
@@ -189,8 +141,9 @@ class VGG(SequentialGrowingModel):
         Width of the first fully-connected layer. Defaults to ``fc_layer_width``
         when ``None``.
     input_spatial_shape : tuple[int, int] | None
-        Spatial dimensions ``(H, W)`` of the input feature maps. Required when
-        ``normalization="layer"``.
+        Spatial dimensions ``(H, W)`` of the input. Used to compute the
+        feature-map size before the classifier. When ``None``, an
+        ``AdaptiveAvgPool2d(7, 7)`` is used.
     device : torch.device | str | None
         Device to run the model on.
     growing_conv_type : type[Conv2dGrowingModule]
@@ -202,7 +155,6 @@ class VGG(SequentialGrowingModel):
     ValueError
         If ``number_of_fc_layers`` is not positive, ``fc_layer_width`` is not
         positive, ``initial_fc_layer_width`` is not positive,
-        ``normalization="layer"`` and ``input_spatial_shape`` is ``None``,
         or ``target_cfg`` does not match the pooling structure of ``cfg``.
     """
 
@@ -212,7 +164,7 @@ class VGG(SequentialGrowingModel):
         target_cfg: list[str | int] | None = None,
         in_features: int = 3,
         activation: nn.Module = nn.ReLU(inplace=True),
-        normalization: NormalizationType | None = "batch",
+        normalization: VggNormalizationType | None = "batch",
         normalization_kwargs: NormKwargs | None = None,
         num_classes: int = 1000,
         init_weights: bool = True,
@@ -237,7 +189,7 @@ class VGG(SequentialGrowingModel):
             )
 
         self.activation = activation.to(device)
-        self.normalization: NormalizationType | None = self._validate_normalization(
+        self.normalization: VggNormalizationType | None = self._validate_normalization(
             normalization
         )
         self.normalization_kwargs: CompleteNormKwargs = base_norm_kwargs.copy()
@@ -248,13 +200,8 @@ class VGG(SequentialGrowingModel):
         self.initial_fc_layer_width = (
             fc_layer_width if initial_fc_layer_width is None else initial_fc_layer_width
         )
-        self.input_spatial_shape = input_spatial_shape
-        if self.normalization == "layer" and self.input_spatial_shape is None:
-            raise ValueError(
-                "input_spatial_shape must be provided when normalization='layer'."
-            )
 
-        current_spatial_shape = self.input_spatial_shape
+        current_spatial_shape = input_spatial_shape
 
         self.features = nn.Sequential()
         self.flatten = nn.Flatten(1)
@@ -296,7 +243,6 @@ class VGG(SequentialGrowingModel):
                 tuple(stage_channels),
                 tuple(target_stage_channels),
                 in_channels=in_channels,
-                spatial_shape=current_spatial_shape,
                 build_post_conv_layers=self._build_post_conv_layers,
                 growing_conv_type=growing_conv_type,
                 device=self.device,
@@ -425,9 +371,7 @@ class VGG(SequentialGrowingModel):
                 )
                 if module.bias is not None:
                     nn.init.constant_(module.bias, 0)
-            elif isinstance(
-                module, (GrowingBatchNorm2d, GrowingGroupNorm, GrowingLayerNorm)
-            ):
+            elif isinstance(module, (GrowingBatchNorm2d, GrowingGroupNorm)):
                 if module.weight is not None:
                     nn.init.constant_(module.weight, 1)
                 if module.bias is not None:
@@ -438,15 +382,14 @@ class VGG(SequentialGrowingModel):
 
     @staticmethod
     def _validate_normalization(
-        normalization: NormalizationType | None,
-    ) -> NormalizationType | None:
+        normalization: VggNormalizationType | None,
+    ) -> VggNormalizationType | None:
         if normalization is None:
             return None
-        if normalization in {"batch", "group", "layer"}:
+        if normalization in {"batch", "group"}:
             return normalization
         raise ValueError(
-            "normalization must be 'batch', 'group', 'layer' or None, "
-            f"got {normalization!r}."
+            f"normalization must be 'batch', 'group' or None, got {normalization!r}."
         )
 
     def _update_normalization_kwargs(self, normalization_kwargs: NormKwargs) -> None:
@@ -458,7 +401,6 @@ class VGG(SequentialGrowingModel):
     def _build_growing_normalization(
         self,
         num_channels: int,
-        spatial_shape: tuple[int, int] | None = None,
     ) -> nn.Module | None:
         if self.normalization is None:
             return None
@@ -479,26 +421,10 @@ class VGG(SequentialGrowingModel):
                 affine=self.normalization_kwargs["affine"],
                 device=self.device,
             )
-        if self.normalization == "layer":
-            if spatial_shape is None:
-                raise ValueError(
-                    "spatial_shape must be provided when normalization='layer'."
-                )
-            return GrowingLayerNorm(
-                [num_channels, *spatial_shape],
-                eps=self.normalization_kwargs["eps"],
-                elementwise_affine=self.normalization_kwargs["elementwise_affine"],
-                bias=self.normalization_kwargs["bias"],
-                device=self.device,
-            )
-        raise AssertionError("Normalization should have been validated before use.")
+        raise ValueError(f"Unsupported normalization {self.normalization!r}.")
 
-    def _build_post_conv_layers(
-        self,
-        num_channels: int,
-        spatial_shape: tuple[int, int] | None = None,
-    ) -> nn.Module:
-        normalization = self._build_growing_normalization(num_channels, spatial_shape)
+    def _build_post_conv_layers(self, num_channels: int) -> nn.Module:
+        normalization = self._build_growing_normalization(num_channels)
         layers: list[nn.Module] = []
         if normalization is not None:
             layers.append(normalization)
@@ -556,7 +482,7 @@ def init_full_vgg_structure(
     out_features: int = 1000,
     device: torch.device | str | None = None,
     activation: nn.Module = nn.ReLU(inplace=True),
-    normalization: NormalizationType | None = "batch",
+    normalization: VggNormalizationType | None = "batch",
     normalization_kwargs: NormKwargs | None = None,
     hidden_channels: tuple[int | tuple[int, ...], ...] | None = None,
     number_of_conv_per_stage: int | tuple[int, ...] = (1, 1, 2, 2, 2),
@@ -584,15 +510,14 @@ def init_full_vgg_structure(
     activation : nn.Module
         Activation function to use after each normalized convolution/linear
         block in the feature extractor and classifier hidden layers.
-    normalization : NormalizationType | None
+    normalization : VggNormalizationType | None
         Normalization layer to use. Supported values are ``"batch"``,
-        ``"group"``, ``"layer"``, and ``None``.
+        ``"group"``, and ``None``.
     normalization_kwargs : NormKwargs | None
         Additional keyword arguments passed to the selected normalization layer.
         Supported keys are:
         ``eps``, ``momentum``, ``affine``, ``track_running_stats`` for batch norm;
-        ``num_groups``, ``eps``, ``affine`` for group norm;
-        ``eps``, ``elementwise_affine``, ``bias`` for layer norm.
+        ``num_groups``, ``eps``, ``affine`` for group norm.
     hidden_channels : tuple[int | tuple[int, ...], ...] | None
         Explicit channels per stage/block. If provided, each stage entry can be:
         - int: same width for all blocks in the stage

--- a/src/gromo/containers/vgg.py
+++ b/src/gromo/containers/vgg.py
@@ -512,6 +512,32 @@ def _reduce_growing_conv_widths(
     stage_hidden_per_block: tuple[int, ...],
     reduction_factor: float | None,
 ) -> tuple[int, ...]:
+    """Scale down all but the last block width in a stage by a reduction factor.
+
+    The last block retains its target width; earlier blocks are multiplied by
+    ``reduction_factor`` (rounded up) so they start smaller and can grow toward
+    the target.
+
+    Parameters
+    ----------
+    stage_hidden_per_block : tuple[int, ...]
+        Target channel widths, one per convolutional block in the stage.
+    reduction_factor : float | None
+        Multiplicative factor applied to non-final block widths.
+        If ``None``, the input tuple is returned unchanged.
+
+    Returns
+    -------
+    tuple[int, ...]
+        Widths after reduction, same length as ``stage_hidden_per_block``.
+
+    Examples
+    --------
+    >>> _reduce_growing_conv_widths((256, 256, 512), reduction_factor=0.5)
+    (128, 128, 512)
+    >>> _reduce_growing_conv_widths((256, 512), reduction_factor=None)
+    (256, 512)
+    """
     if reduction_factor is None:
         return stage_hidden_per_block
     return tuple(

--- a/src/gromo/containers/vgg.py
+++ b/src/gromo/containers/vgg.py
@@ -111,7 +111,6 @@ class _VGGStageBlock(nn.Module):
 
         previous_growing_layer: Conv2dGrowingModule | None = None
         current_in_channels = in_channels
-        stage_target_out_channels = target_stage_channels[0]
         for layer_index, (out_channels, _) in enumerate(
             zip(stage_channels, target_stage_channels, strict=True)
         ):
@@ -120,7 +119,9 @@ class _VGGStageBlock(nn.Module):
                 out_channels,
                 spatial_shape,
             )
-            target_in_channels = None if is_first_conv else stage_target_out_channels
+            target_in_channels = (
+                None if is_first_conv else target_stage_channels[layer_index - 1]
+            )
             conv = growing_conv_type(
                 in_channels=current_in_channels,
                 out_channels=out_channels,
@@ -278,7 +279,7 @@ class VGG(SequentialGrowingModel):
             self._feature_growing_modules.extend(stage_block.growing_modules)
             growable_layers.extend(stage_block.growable_layers)
             in_channels = stage_block.out_channels
-            current_stage_target_out_channels = target_stage_channels[0]
+            current_stage_target_out_channels = target_stage_channels[-1]
             if has_pool:
                 self.features.append(nn.MaxPool2d(kernel_size=2, stride=2))
                 feature_module_index += 1
@@ -509,7 +510,9 @@ def _reduce_growing_conv_widths(
     if reduction_factor is None:
         return stage_hidden_per_block
     return tuple(
-        stage_width if block_idx == 0 else ceil(stage_width * reduction_factor)
+        stage_width
+        if block_idx == len(stage_hidden_per_block) - 1
+        else ceil(stage_width * reduction_factor)
         for block_idx, stage_width in enumerate(stage_hidden_per_block)
     )
 

--- a/src/gromo/modules/growing_normalisation.py
+++ b/src/gromo/modules/growing_normalisation.py
@@ -1,7 +1,63 @@
-from typing import Callable
+"""Growing normalization layers and shared normalization configuration types."""
+
+from typing import Callable, Literal, TypeAlias, TypedDict
 
 import torch
 import torch.nn as nn
+
+
+# ---------------------------------------------------------------------------
+# Shared normalization configuration types
+# ---------------------------------------------------------------------------
+
+NormalizationType: TypeAlias = Literal["batch", "group", "layer"]
+#: Normalization types supported across growing containers.
+
+
+class NormKwargs(TypedDict, total=False):
+    """Optional normalization keyword arguments (superset of all norm types).
+
+    Each normalization type uses only the relevant keys:
+
+    - ``"batch"``: ``eps``, ``momentum``, ``affine``, ``track_running_stats``
+    - ``"group"``: ``num_groups``, ``eps``, ``affine``
+    - ``"layer"``: ``eps``, ``elementwise_affine``, ``bias``
+    """
+
+    # BatchNorm keys
+    eps: float
+    momentum: float
+    affine: bool
+    track_running_stats: bool
+    # GroupNorm key
+    num_groups: int
+    # LayerNorm keys
+    elementwise_affine: bool
+    bias: bool
+
+
+class CompleteNormKwargs(TypedDict):
+    """Complete normalization configuration (all keys required)."""
+
+    eps: float
+    momentum: float
+    affine: bool
+    track_running_stats: bool
+    num_groups: int
+    elementwise_affine: bool
+    bias: bool
+
+
+base_norm_kwargs: CompleteNormKwargs = {
+    "eps": 1e-5,
+    "momentum": 0.1,
+    "affine": True,
+    "track_running_stats": True,
+    "num_groups": 1,
+    "elementwise_affine": True,
+    "bias": True,
+}
+#: Default normalization kwargs used when no overrides are provided.
 
 
 class GrowingBatchNorm(nn.modules.batchnorm._BatchNorm):
@@ -396,7 +452,10 @@ class GrowingLayerNorm(nn.LayerNorm):
 
         # Validate custom tensor shapes before any mutation
         if getattr(self, "elementwise_affine", False):
-            weight_required_shape = (additional_first_dim, *tuple(self.weight.shape[1:]))
+            weight_required_shape = (
+                additional_first_dim,
+                *tuple(self.weight.shape[1:]),
+            )
             if (
                 new_weights is not None
                 and tuple(new_weights.shape) != weight_required_shape
@@ -407,7 +466,10 @@ class GrowingLayerNorm(nn.LayerNorm):
                 )
 
             if getattr(self, "bias", None) is not None and new_biases is not None:
-                bias_required_shape = (additional_first_dim, *tuple(self.bias.shape[1:]))
+                bias_required_shape = (
+                    additional_first_dim,
+                    *tuple(self.bias.shape[1:]),
+                )
                 if tuple(new_biases.shape) != bias_required_shape:
                     raise ValueError(
                         f"new_bias must have shape {bias_required_shape}, "

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING
 import torch
 
 from gromo.containers.resnet import (
-    NormKwargs,
     ResNetBasicBlock,
     init_full_resnet_structure,
 )
@@ -13,6 +12,7 @@ from tests.unittest_tools import unittest_parametrize
 
 if TYPE_CHECKING:
     from gromo.containers.growing_block import Conv2dGrowingBlock
+    from gromo.modules.growing_normalisation import NormKwargs
 
 
 try:

--- a/tests/test_vgg.py
+++ b/tests/test_vgg.py
@@ -7,16 +7,15 @@ import torch.nn as nn
 import gromo.containers.vgg as vgg_module
 from gromo.containers.vgg import (
     VGG,
-    NormKwargs,
     _reduce_growing_conv_widths,
-    base_norm_kwargs,
     init_full_vgg_structure,
 )
 from gromo.modules.conv2d_growing_module import Conv2dGrowingModule
 from gromo.modules.growing_normalisation import (
     GrowingBatchNorm2d,
     GrowingGroupNorm,
-    GrowingLayerNorm,
+    NormKwargs,
+    base_norm_kwargs,
 )
 from gromo.modules.linear_growing_module import LinearGrowingModule
 from gromo.utils.utils import global_device
@@ -368,8 +367,7 @@ class TestVGG(TorchTestCase):
                 stage_channels=(8,),
                 target_stage_channels=(8, 8),
                 in_channels=3,
-                spatial_shape=(32, 32),
-                build_post_conv_layers=lambda *_: nn.Identity(),
+                build_post_conv_layers=lambda _: nn.Identity(),
                 growing_conv_type=Conv2dGrowingModule,
                 device=torch.device("cpu"),
                 name="bad_stage",
@@ -380,8 +378,7 @@ class TestVGG(TorchTestCase):
                 stage_channels=(),
                 target_stage_channels=(),
                 in_channels=3,
-                spatial_shape=(32, 32),
-                build_post_conv_layers=lambda *_: nn.Identity(),
+                build_post_conv_layers=lambda _: nn.Identity(),
                 growing_conv_type=Conv2dGrowingModule,
                 device=torch.device("cpu"),
                 name="empty_stage",
@@ -441,7 +438,8 @@ class TestVGG(TorchTestCase):
         self.assertEqual(VGG._validate_normalization(None), None)
         self.assertEqual(VGG._validate_normalization("batch"), "batch")
         self.assertEqual(VGG._validate_normalization("group"), "group")
-        self.assertEqual(VGG._validate_normalization("layer"), "layer")
+        with self.assertRaises(ValueError):
+            VGG._validate_normalization("layer")  # type: ignore[arg-type]
         with self.assertRaises(ValueError):
             VGG._validate_normalization("instance")  # type: ignore[arg-type]
 
@@ -449,11 +447,11 @@ class TestVGG(TorchTestCase):
         self.assertIsInstance(activation_copy, nn.ReLU)
         self.assertIsNot(activation_copy, model.activation)
 
-        normalization = model._build_growing_normalization(4, (32, 32))
+        normalization = model._build_growing_normalization(4)
         self.assertIsInstance(normalization, GrowingBatchNorm2d)
         self.assertEqual(normalization.eps, 1e-3)
 
-        post_conv_layers = model._build_post_conv_layers(4, (32, 32))
+        post_conv_layers = model._build_post_conv_layers(4)
         self.assertIsInstance(post_conv_layers, nn.Sequential)
 
         model._update_normalization_kwargs({"momentum": 0.25})
@@ -465,24 +463,14 @@ class TestVGG(TorchTestCase):
         self.assertEqual(model.normalization_kwargs["num_groups"], 4)
         self.assertEqual(model.normalization_kwargs["momentum"], 0.1)
 
-        model.normalization = "layer"
-        model._update_normalization_kwargs({"bias": False})
-        self.assertFalse(model.normalization_kwargs["bias"])
-        model._update_normalization_kwargs({"unknown_layer_key": False})  # type: ignore[arg-type]
-
-        layer_norm = model._build_growing_normalization(4, (32, 32))
-        self.assertIsInstance(layer_norm, GrowingLayerNorm)
-        with self.assertRaises(ValueError):
-            model._build_growing_normalization(4)
-
         model.normalization = None
-        self.assertIsNone(model._build_growing_normalization(4, (32, 32)))
-        post_conv_without_norm = model._build_post_conv_layers(4, (32, 32))
+        self.assertIsNone(model._build_growing_normalization(4))
+        post_conv_without_norm = model._build_post_conv_layers(4)
         self.assertIsInstance(post_conv_without_norm, nn.ReLU)
 
         model.normalization = "invalid"  # type: ignore[assignment]
-        with self.assertRaises(AssertionError):
-            model._build_growing_normalization(4, (32, 32))
+        with self.assertRaises(ValueError):
+            model._build_growing_normalization(4)
 
         with self.assertRaises(ValueError):
             VGG(
@@ -688,35 +676,6 @@ class TestVGG(TorchTestCase):
         self.assertEqual(group_norm_layers[0].eps, 1e-4)
         self.assertFalse(group_norm_layers[0].affine)
         self.assertShapeEqual(group_model(x), (2, 7))
-
-        layer_model = init_full_vgg_structure(
-            input_shape=(3, 32, 32),
-            out_features=7,
-            nb_stages=3,
-            number_of_conv_per_stage=(1, 2, 1),
-            hidden_channels=(8, 16, 32),
-            normalization="layer",
-            normalization_kwargs={
-                "eps": 1e-4,
-                "elementwise_affine": False,
-                "bias": False,
-            },
-            reduction_factor=None,
-            device=device,
-            init_weights=False,
-        )
-        layer_norm_layers = [
-            module
-            for module in layer_model.modules()
-            if isinstance(module, GrowingLayerNorm)
-        ]
-        self.assertGreater(len(layer_norm_layers), 0)
-        self.assertEqual(layer_norm_layers[0].normalized_shape, (8, 32, 32))
-        self.assertEqual(layer_norm_layers[1].normalized_shape, (16, 16, 16))
-        self.assertEqual(layer_norm_layers[2].normalized_shape, (16, 16, 16))
-        self.assertFalse(layer_norm_layers[0].elementwise_affine)
-        self.assertIsNone(layer_norm_layers[0].bias)
-        self.assertShapeEqual(layer_model(x), (2, 7))
 
     def test_forward_backward(self):
         """Test forward and backward passes of the initialized VGG model."""
@@ -1054,25 +1013,6 @@ class TestVGG(TorchTestCase):
         self.assertIsNone(group_norm.weight)
         self.assertIsNone(group_norm.bias)
         group_model._initialize_weights()
-
-        layer_model = init_full_vgg_structure(
-            input_shape=(3, 32, 32),
-            out_features=10,
-            nb_stages=2,
-            number_of_conv_per_stage=(1, 1),
-            hidden_channels=(8, 16),
-            normalization="layer",
-            normalization_kwargs={"elementwise_affine": True, "bias": False},
-            init_weights=False,
-        )
-        layer_norm = next(
-            module
-            for module in layer_model.modules()
-            if isinstance(module, GrowingLayerNorm)
-        )
-        self.assertIsNotNone(layer_norm.weight)
-        self.assertIsNone(layer_norm.bias)
-        layer_model._initialize_weights()
 
     def test_custom_activation_and_classifier_configuration(self):
         """Test custom activation wiring and configurable classifier layout."""

--- a/tests/test_vgg.py
+++ b/tests/test_vgg.py
@@ -274,7 +274,7 @@ class TestVGG(TorchTestCase):
         with self.assertRaises(ValueError):
             init_full_vgg_structure(reduction_factor=1.5)
 
-        with patch.object(vgg_module, "min", return_value=0):
+        with patch.object(vgg_module, "min", return_value=0, create=True):
             with self.assertRaises(ValueError):
                 init_full_vgg_structure(
                     nb_stages=1,

--- a/tests/test_vgg.py
+++ b/tests/test_vgg.py
@@ -212,7 +212,7 @@ class TestVGG(TorchTestCase):
         )
         self.assertEqual(self._first_conv(model_explicit_in).in_channels, 2)
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(ValueError):
             init_full_vgg_structure(input_shape=torch.Size((3, 32)))  # type: ignore[arg-type]
 
         with self.assertRaises(TypeError):

--- a/tests/test_vgg.py
+++ b/tests/test_vgg.py
@@ -130,7 +130,7 @@ class TestVGG(TorchTestCase):
         self.assertIsInstance(model, VGG)
         self.assertEqual(
             self._stage_conv_widths(model),
-            [(64,), (128,), (256, 8), (512, 16), (512, 16)],
+            [(64,), (128,), (8, 256), (16, 512), (16, 512)],
         )
         self.assertEqual(
             self._conv_allow_growing_flags(model),
@@ -152,7 +152,7 @@ class TestVGG(TorchTestCase):
         )
         self.assertEqual(
             self._stage_conv_widths(model_varied_blocks),
-            [(64,), (128, 4), (256, 8, 8), (512,), (512, 16)],
+            [(64,), (4, 128), (8, 8, 256), (512,), (16, 512)],
         )
         self.assertEqual(
             self._conv_allow_growing_flags(model_varied_blocks),
@@ -165,7 +165,7 @@ class TestVGG(TorchTestCase):
         )
         self.assertEqual(
             self._stage_conv_widths(model_with_higher_reduction_factor),
-            [(64,), (128, 32), (256, 64, 64), (512,), (512, 128)],
+            [(64,), (32, 128), (64, 64, 256), (512,), (128, 512)],
         )
 
         model_without_reduction = init_full_vgg_structure(
@@ -183,7 +183,7 @@ class TestVGG(TorchTestCase):
         )
         self.assertEqual(
             self._stage_conv_widths(model_hidden_int),
-            [(16, 1), (32, 1), (64, 2), (128, 4), (256, 8)],
+            [(1, 16), (1, 32), (2, 64), (4, 128), (8, 256)],
         )
 
         model_hidden_mixed = init_full_vgg_structure(
@@ -192,7 +192,7 @@ class TestVGG(TorchTestCase):
         )
         self.assertEqual(
             self._stage_conv_widths(model_hidden_mixed),
-            [(16, 1), (32, 2), (64, 2), (128, 4), (192, 8)],
+            [(1, 16), (1, 48), (2, 64), (4, 128), (6, 256)],
         )
 
         model_torch_size = init_full_vgg_structure(
@@ -568,7 +568,7 @@ class TestVGG(TorchTestCase):
         )
         self.assertEqual(
             _reduce_growing_conv_widths((16, 16, 16), 0.25),
-            (16, 4, 4),
+            (4, 4, 16),
         )
 
         classifier_growth_model = VGG(
@@ -604,13 +604,15 @@ class TestVGG(TorchTestCase):
 
         self.assertEqual(
             self._stage_conv_widths(model),
-            [(32,), (64, 8, 8), (128, 16, 16)],
+            [(32,), (8, 8, 64), (16, 16, 128)],
         )
         self.assertEqual(model.final_spatial_shape, (4, 4))
         self.assertEqual(
             self._growable_layer_targets(model),
             [
                 ("RestrictedConv2dGrowingModule", 8, 64),
+                ("RestrictedConv2dGrowingModule", 8, 64),
+                ("RestrictedConv2dGrowingModule", 16, 128),
                 ("RestrictedConv2dGrowingModule", 16, 128),
             ],
         )
@@ -626,8 +628,10 @@ class TestVGG(TorchTestCase):
         self.assertEqual(
             self._growable_layer_targets(mixed_model),
             [
-                ("RestrictedConv2dGrowingModule", 5, 24),
-                ("RestrictedConv2dGrowingModule", 10, 48),
+                ("RestrictedConv2dGrowingModule", 3, 24),
+                ("RestrictedConv2dGrowingModule", 5, 40),
+                ("RestrictedConv2dGrowingModule", 6, 48),
+                ("RestrictedConv2dGrowingModule", 10, 80),
             ],
         )
 
@@ -912,7 +916,8 @@ class TestVGG(TorchTestCase):
             device=torch.device("cpu"),
         )
 
-        feature_layer = model._feature_growing_modules[3]
+        feature_layer = model._growable_layers[0]
+        assert isinstance(feature_layer, Conv2dGrowingModule)
         classifier_layer = model._classifier_growing_modules[0]
 
         model.set_growing_layers(index=0)
@@ -994,6 +999,17 @@ class TestVGG(TorchTestCase):
 
         self.assertGreater(layer.in_neurons, initial_in_neurons)
         self.assertEqual(layer.missing_neurons(), 0)
+        full_model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            out_features=10,
+            nb_stages=3,
+            number_of_conv_per_stage=(1, 3, 3),
+            hidden_channels=(32, 64, 128),
+            number_of_fc_layers=1,
+            reduction_factor=1.0,
+            device=torch.device("cpu"),
+        )
+        self.assertEqual(model.number_of_parameters(), full_model.number_of_parameters())
 
         model.set_growing_layers(scheduling_method="all")
         self.assertTrue(

--- a/tests/test_vgg.py
+++ b/tests/test_vgg.py
@@ -1,0 +1,1132 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+import torch.nn as nn
+
+import gromo.containers.vgg as vgg_module
+from gromo.containers.vgg import (
+    VGG,
+    NormKwargs,
+    _reduce_growing_conv_widths,
+    base_batch_norm_kwargs,
+    init_full_vgg_structure,
+)
+from gromo.modules.conv2d_growing_module import Conv2dGrowingModule
+from gromo.modules.growing_normalisation import (
+    GrowingBatchNorm2d,
+    GrowingGroupNorm,
+    GrowingLayerNorm,
+)
+from gromo.modules.linear_growing_module import LinearGrowingModule
+from gromo.utils.utils import global_device
+from tests.torch_unittest import TorchTestCase
+
+
+try:
+    from torchvision.models import vgg11, vgg11_bn
+
+    HAS_TORCHVISION = True
+except ImportError:
+    HAS_TORCHVISION = False
+
+
+class TestVGG(TorchTestCase):
+    """Test the configurable VGG initializer and growth behavior."""
+
+    def setUp(self) -> None:
+        torch.manual_seed(0)
+
+    @staticmethod
+    def _stage_conv_widths(model: VGG) -> list[tuple[int, ...]]:
+        return [
+            tuple(conv.out_features for conv in stage_block.growing_modules)
+            for stage_block in model.stage_blocks
+        ]
+
+    @staticmethod
+    def _conv_allow_growing_flags(model: VGG) -> list[bool]:
+        return [bool(module._allow_growing) for module in model._feature_growing_modules]
+
+    @staticmethod
+    def _growable_layer_targets(model: VGG) -> list[tuple[str, int, int | None]]:
+        return [
+            (type(layer).__name__, int(layer.in_neurons), layer.target_in_neurons)
+            for layer in model._growable_layers
+        ]
+
+    @staticmethod
+    def _first_conv(model: VGG) -> Conv2dGrowingModule:
+        return model._feature_growing_modules[0]
+
+    @staticmethod
+    def _classifier_linears(model: VGG) -> list[LinearGrowingModule]:
+        return [
+            module
+            for module in model.classifier
+            if isinstance(module, LinearGrowingModule)
+        ]
+
+    @staticmethod
+    def _copy_torchvision_vgg_weights(reference: nn.Module, model: VGG) -> None:
+        reference_convs = [
+            module for module in reference.features if isinstance(module, nn.Conv2d)
+        ]
+        model_convs = model._feature_growing_modules
+        assert len(reference_convs) == len(model_convs)
+        for ref_conv, model_conv in zip(reference_convs, model_convs, strict=True):
+            with torch.no_grad():
+                model_conv.weight.copy_(ref_conv.weight)
+                assert model_conv.bias is not None
+                assert ref_conv.bias is not None
+                model_conv.bias.copy_(ref_conv.bias)
+
+        reference_bns = [
+            module for module in reference.features if isinstance(module, nn.BatchNorm2d)
+        ]
+        model_bns = [
+            module
+            for module in model.features.modules()
+            if isinstance(module, GrowingBatchNorm2d)
+        ]
+        assert len(reference_bns) == len(model_bns)
+        for ref_bn, model_bn in zip(reference_bns, model_bns, strict=True):
+            with torch.no_grad():
+                if model_bn.weight is not None:
+                    assert ref_bn.weight is not None
+                    model_bn.weight.copy_(ref_bn.weight)
+                if model_bn.bias is not None:
+                    assert ref_bn.bias is not None
+                    model_bn.bias.copy_(ref_bn.bias)
+                if model_bn.running_mean is not None:
+                    assert ref_bn.running_mean is not None
+                    model_bn.running_mean.copy_(ref_bn.running_mean)
+                if model_bn.running_var is not None:
+                    assert ref_bn.running_var is not None
+                    model_bn.running_var.copy_(ref_bn.running_var)
+                if model_bn.num_batches_tracked is not None:
+                    assert ref_bn.num_batches_tracked is not None
+                    model_bn.num_batches_tracked.copy_(ref_bn.num_batches_tracked)
+
+        reference_linears = [
+            module for module in reference.classifier if isinstance(module, nn.Linear)
+        ]
+        model_linears = TestVGG._classifier_linears(model)
+        assert len(reference_linears) == len(model_linears)
+        for ref_linear, model_linear in zip(
+            reference_linears, model_linears, strict=True
+        ):
+            with torch.no_grad():
+                model_linear.weight.copy_(ref_linear.weight)
+                assert model_linear.bias is not None
+                assert ref_linear.bias is not None
+                model_linear.bias.copy_(ref_linear.bias)
+
+    def test_init_full_vgg_structure_variations(self):
+        """Test init_full_vgg_structure with valid and invalid configurations."""
+        model = (
+            init_full_vgg_structure()
+        )  # By default grown VGG11, with resolution_factor 1/32
+        self.assertIsInstance(model, VGG)
+        self.assertEqual(
+            self._stage_conv_widths(model),
+            [(64,), (128,), (256, 8), (512, 16), (512, 16)],
+        )
+        self.assertEqual(
+            self._conv_allow_growing_flags(model),
+            [False, False, False, True, False, True, False, True],
+        )
+
+        model_single_block = init_full_vgg_structure(number_of_conv_per_stage=1)
+        self.assertEqual(
+            self._stage_conv_widths(model_single_block),
+            [(64,), (128,), (256,), (512,), (512,)],
+        )
+        self.assertEqual(
+            self._conv_allow_growing_flags(model_single_block),
+            [False, False, False, False, False],
+        )
+
+        model_varied_blocks = init_full_vgg_structure(
+            number_of_conv_per_stage=(1, 2, 3, 1, 2),
+        )
+        self.assertEqual(
+            self._stage_conv_widths(model_varied_blocks),
+            [(64,), (128, 4), (256, 8, 8), (512,), (512, 16)],
+        )
+        self.assertEqual(
+            self._conv_allow_growing_flags(model_varied_blocks),
+            [False, False, True, False, True, True, False, False, True],
+        )
+
+        model_with_higher_reduction_factor = init_full_vgg_structure(
+            number_of_conv_per_stage=(1, 2, 3, 1, 2),
+            reduction_factor=0.25,
+        )
+        self.assertEqual(
+            self._stage_conv_widths(model_with_higher_reduction_factor),
+            [(64,), (128, 32), (256, 64, 64), (512,), (512, 128)],
+        )
+
+        model_without_reduction = init_full_vgg_structure(
+            number_of_conv_per_stage=(1, 2, 3, 1, 2),
+            reduction_factor=None,
+        )
+        self.assertEqual(
+            self._stage_conv_widths(model_without_reduction),
+            [(64,), (128, 128), (256, 256, 256), (512,), (512, 512)],
+        )
+
+        model_hidden_int = init_full_vgg_structure(
+            hidden_channels=(16, 32, 64, 128, 256),
+            number_of_conv_per_stage=2,
+        )
+        self.assertEqual(
+            self._stage_conv_widths(model_hidden_int),
+            [(16, 1), (32, 1), (64, 2), (128, 4), (256, 8)],
+        )
+
+        model_hidden_mixed = init_full_vgg_structure(
+            hidden_channels=(16, (32, 48), 64, 128, (192, 256)),
+            number_of_conv_per_stage=2,
+        )
+        self.assertEqual(
+            self._stage_conv_widths(model_hidden_mixed),
+            [(16, 1), (32, 2), (64, 2), (128, 4), (192, 8)],
+        )
+
+        model_torch_size = init_full_vgg_structure(
+            input_shape=torch.Size((1, 32, 32)),  # type: ignore[arg-type]
+            nb_stages=3,
+            number_of_conv_per_stage=1,
+            hidden_channels=(8, 16, 32),
+        )
+        self.assertEqual(self._first_conv(model_torch_size).in_channels, 1)
+
+        model_explicit_in = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            in_features=2,
+            nb_stages=3,
+            number_of_conv_per_stage=1,
+            hidden_channels=(8, 16, 32),
+        )
+        self.assertEqual(self._first_conv(model_explicit_in).in_channels, 2)
+
+        with self.assertRaises(AssertionError):
+            init_full_vgg_structure(input_shape=torch.Size((3, 32)))  # type: ignore[arg-type]
+
+        with self.assertRaises(TypeError):
+            init_full_vgg_structure(number_of_conv_per_stage=(1, 2, 3))  # type: ignore[arg-type]
+
+        with self.assertRaises(TypeError):
+            init_full_vgg_structure(
+                number_of_conv_per_stage=(1, "2", 3, 4, 5)  # type: ignore[arg-type]
+            )
+
+        with self.assertRaises(ValueError):
+            init_full_vgg_structure(number_of_conv_per_stage=(1, 0, 3, 4, 5))
+
+        with self.assertRaises(ValueError):
+            init_full_vgg_structure(hidden_channels=(8, 16, 32, 64))
+
+        with self.assertRaises(ValueError):
+            init_full_vgg_structure(
+                hidden_channels=(8, (16, 20, 24), 32, 64, 128),
+                number_of_conv_per_stage=2,
+            )
+
+        with self.assertRaises(TypeError):
+            init_full_vgg_structure(
+                hidden_channels=(8, "invalid", 32, 64, 128),  # type: ignore[arg-type]
+                number_of_conv_per_stage=2,
+            )
+
+        with self.assertRaises(TypeError):
+            init_full_vgg_structure(
+                hidden_channels=(8, (16, "20"), 32, 64, 128),  # type: ignore[arg-type]
+                number_of_conv_per_stage=2,
+            )
+
+        with self.assertRaises(ValueError):
+            init_full_vgg_structure(
+                hidden_channels=(8, (16, 0), 32, 64, 128),
+                number_of_conv_per_stage=2,
+            )
+
+        with self.assertRaises(TypeError):
+            init_full_vgg_structure(number_of_fc_layers="3")  # type: ignore[arg-type]
+
+        with self.assertRaises(ValueError):
+            init_full_vgg_structure(number_of_fc_layers=0)
+
+        with self.assertRaises(TypeError):
+            init_full_vgg_structure(fc_layer_width="64")  # type: ignore[arg-type]
+
+        with self.assertRaises(ValueError):
+            init_full_vgg_structure(fc_layer_width=0)
+
+        with self.assertRaises(TypeError):
+            init_full_vgg_structure(reduction_factor="0.5")  # type: ignore[arg-type]
+
+        with self.assertRaises(ValueError):
+            init_full_vgg_structure(reduction_factor=0)
+
+        with self.assertRaises(ValueError):
+            init_full_vgg_structure(reduction_factor=1.5)
+
+        with patch.object(vgg_module, "min", return_value=0):
+            with self.assertRaises(ValueError):
+                init_full_vgg_structure(
+                    nb_stages=1,
+                    number_of_conv_per_stage=1,
+                    hidden_channels=None,
+                )
+
+    @unittest.skipUnless(HAS_TORCHVISION, "torchvision is not installed")
+    def test_torchvision_vgg11_parity(self):
+        """Temporary parity check against torchvision VGG11."""
+        model = init_full_vgg_structure(
+            input_shape=(3, 224, 224),
+            out_features=1000,
+            normalization=None,
+            number_of_conv_per_stage=(1, 1, 2, 2, 2),
+            hidden_channels=(64, 128, 256, 512, 512),
+            number_of_fc_layers=3,
+            fc_layer_width=4096,
+            reduction_factor=None,
+        )
+        reference = vgg11(weights=None)
+        self._copy_torchvision_vgg_weights(reference, model)
+        model.eval()
+        reference.eval()
+
+        self.assertEqual(model.final_spatial_shape, (7, 7))
+        self.assertEqual(model.avgpool.output_size, (7, 7))
+        self.assertEqual(
+            self._stage_conv_widths(model),
+            [(64,), (128,), (256, 256), (512, 512), (512, 512)],
+        )
+        self.assertEqual(
+            [layer.in_features for layer in self._classifier_linears(model)],
+            [512 * 7 * 7, 4096, 4096],
+        )
+        self.assertEqual(
+            [layer.out_features for layer in self._classifier_linears(model)],
+            [4096, 4096, 1000],
+        )
+        self.assertEqual(
+            sum(parameter.numel() for parameter in model.parameters()),
+            sum(parameter.numel() for parameter in reference.parameters()),
+        )
+
+        x = torch.randn(2, 3, 224, 224)
+        model_output = model(x)
+        reference_output = reference(x)
+        self.assertShapeEqual(model_output, reference_output.shape)
+        self.assertAllClose(model_output, reference_output, atol=1e-6, rtol=1e-6)
+
+    @unittest.skipUnless(HAS_TORCHVISION, "torchvision is not installed")
+    def test_torchvision_vgg11_bn_parity(self):
+        """Temporary parity check against torchvision VGG11 with batch norm."""
+        model = init_full_vgg_structure(
+            input_shape=(3, 224, 224),
+            out_features=1000,
+            normalization="batch",
+            number_of_conv_per_stage=(1, 1, 2, 2, 2),
+            hidden_channels=(64, 128, 256, 512, 512),
+            number_of_fc_layers=3,
+            fc_layer_width=4096,
+            reduction_factor=None,
+        )
+        reference = vgg11_bn(weights=None)
+        self._copy_torchvision_vgg_weights(reference, model)
+        model.eval()
+        reference.eval()
+
+        batch_norm_layers = [
+            module for module in model.modules() if isinstance(module, GrowingBatchNorm2d)
+        ]
+        self.assertEqual(len(batch_norm_layers), 8)
+        self.assertEqual(model.final_spatial_shape, (7, 7))
+        self.assertEqual(
+            sum(parameter.numel() for parameter in model.parameters()),
+            sum(parameter.numel() for parameter in reference.parameters()),
+        )
+
+        x = torch.randn(2, 3, 224, 224)
+        model_output = model(x)
+        reference_output = reference(x)
+        self.assertShapeEqual(model_output, reference_output.shape)
+        self.assertAllClose(model_output, reference_output, atol=1e-6, rtol=1e-6)
+
+    def test_direct_constructor_and_helper_methods(self):
+        """Test direct VGG constructor validation and private helper methods."""
+        with self.assertRaises(ValueError):
+            vgg_module._VGGStageBlock(
+                stage_channels=(8,),
+                target_stage_channels=(8, 8),
+                in_channels=3,
+                spatial_shape=(32, 32),
+                build_post_conv_layers=lambda *_: nn.Identity(),
+                growing_conv_type=Conv2dGrowingModule,
+                device=torch.device("cpu"),
+                name="bad_stage",
+            )
+
+        with self.assertRaises(ValueError):
+            vgg_module._VGGStageBlock(
+                stage_channels=(),
+                target_stage_channels=(),
+                in_channels=3,
+                spatial_shape=(32, 32),
+                build_post_conv_layers=lambda *_: nn.Identity(),
+                growing_conv_type=Conv2dGrowingModule,
+                device=torch.device("cpu"),
+                name="empty_stage",
+            )
+
+        default_target_model = VGG(
+            cfg=[8, "M", 16, "M"],
+            target_cfg=None,
+            in_features=3,
+            normalization="batch",
+            num_classes=5,
+            number_of_fc_layers=1,
+            fc_layer_width=16,
+            input_spatial_shape=(32, 32),
+        )
+        self.assertEqual(len(default_target_model.features), 4)
+        self.assertEqual(default_target_model.final_spatial_shape, (8, 8))
+
+        no_trailing_pool_model = VGG(
+            cfg=["M", 8, "M", 16],
+            target_cfg=["M", 8, "M", 16],
+            in_features=3,
+            normalization="batch",
+            num_classes=5,
+            number_of_fc_layers=1,
+            fc_layer_width=16,
+            input_spatial_shape=(32, 32),
+        )
+        self.assertEqual(len(no_trailing_pool_model.stage_blocks), 2)
+        self.assertEqual(no_trailing_pool_model.final_spatial_shape, (16, 16))
+
+        no_spatial_shape_model = VGG(
+            cfg=[8, "M", 16, "M"],
+            target_cfg=None,
+            in_features=3,
+            normalization="batch",
+            num_classes=5,
+            number_of_fc_layers=1,
+            fc_layer_width=16,
+        )
+        self.assertEqual(len(no_spatial_shape_model.features), 4)
+        self.assertEqual(no_spatial_shape_model.final_spatial_shape, (7, 7))
+
+        cfg = [8, "M", 16, 4, "M"]
+        model = VGG(
+            cfg=cfg,
+            target_cfg=[8, "M", 16, 16, "M"],
+            in_features=3,
+            normalization="batch",
+            normalization_kwargs={"eps": 1e-3},
+            num_classes=5,
+            number_of_fc_layers=1,
+            fc_layer_width=16,
+            input_spatial_shape=(32, 32),
+        )
+
+        self.assertEqual(VGG._validate_normalization(None), None)
+        self.assertEqual(VGG._validate_normalization("batch"), "batch")
+        self.assertEqual(VGG._validate_normalization("group"), "group")
+        self.assertEqual(VGG._validate_normalization("layer"), "layer")
+        with self.assertRaises(ValueError):
+            VGG._validate_normalization("instance")  # type: ignore[arg-type]
+
+        activation_copy = model._make_activation()
+        self.assertIsInstance(activation_copy, nn.ReLU)
+        self.assertIsNot(activation_copy, model.activation)
+
+        normalization = model._build_growing_normalization(4, (32, 32))
+        self.assertIsInstance(normalization, GrowingBatchNorm2d)
+        self.assertEqual(normalization.eps, 1e-3)
+
+        post_conv_layers = model._build_post_conv_layers(4, (32, 32))
+        self.assertIsInstance(post_conv_layers, nn.Sequential)
+
+        model._update_batch_norm_kwargs({"momentum": 0.25})
+        self.assertEqual(model.batch_norm_kwargs["momentum"], 0.25)
+        with self.assertRaises(ValueError):
+            model._update_batch_norm_kwargs({"unknown": 1.0})  # type: ignore[arg-type]
+
+        model.normalization = "group"
+        model._update_group_norm_kwargs({"num_groups": 4})
+        self.assertEqual(model.group_norm_kwargs["num_groups"], 4)
+        with self.assertRaises(ValueError):
+            model._update_group_norm_kwargs({"momentum": 0.1})  # type: ignore[arg-type]
+
+        model.normalization = "layer"
+        model._update_layer_norm_kwargs({"bias": False})
+        self.assertFalse(model.layer_norm_kwargs["bias"])
+        with self.assertRaises(ValueError):
+            model._update_layer_norm_kwargs({"affine": False})  # type: ignore[arg-type]
+
+        layer_norm = model._build_growing_normalization(4, (32, 32))
+        self.assertIsInstance(layer_norm, GrowingLayerNorm)
+        with self.assertRaises(ValueError):
+            model._build_growing_normalization(4)
+
+        model.normalization = None
+        self.assertIsNone(model._build_growing_normalization(4, (32, 32)))
+        post_conv_without_norm = model._build_post_conv_layers(4, (32, 32))
+        self.assertIsInstance(post_conv_without_norm, nn.ReLU)
+
+        model.normalization = "invalid"  # type: ignore[assignment]
+        with self.assertRaises(AssertionError):
+            model._build_growing_normalization(4, (32, 32))
+
+        with self.assertRaises(ValueError):
+            VGG(
+                cfg=[8, "M"],
+                target_cfg=[8, 16],
+                normalization="batch",
+                num_classes=3,
+                number_of_fc_layers=1,
+                fc_layer_width=8,
+                input_spatial_shape=(32, 32),
+            )
+
+        with self.assertRaises(ValueError):
+            VGG(
+                cfg=[8, "M"],
+                target_cfg=[8, "M"],
+                normalization=None,
+                normalization_kwargs={"eps": 1e-4},
+                num_classes=3,
+                number_of_fc_layers=1,
+                fc_layer_width=8,
+                input_spatial_shape=(32, 32),
+            )
+
+        with self.assertRaises(ValueError):
+            VGG(
+                cfg=[8, "M"],
+                target_cfg=[8, "M"],
+                normalization="batch",
+                num_classes=3,
+                number_of_fc_layers=0,
+                input_spatial_shape=(32, 32),
+            )
+
+        with self.assertRaises(ValueError):
+            VGG(
+                cfg=[8, "M"],
+                target_cfg=[8, "M"],
+                normalization="batch",
+                num_classes=3,
+                number_of_fc_layers=1,
+                fc_layer_width=0,
+                input_spatial_shape=(32, 32),
+            )
+
+        with self.assertRaises(ValueError):
+            VGG(
+                cfg=[8, "M"],
+                target_cfg=[8, "M"],
+                normalization="batch",
+                num_classes=3,
+                number_of_fc_layers=1,
+                fc_layer_width=8,
+                initial_fc_layer_width=0,
+                input_spatial_shape=(32, 32),
+            )
+
+        with self.assertRaises(ValueError):
+            VGG(
+                cfg=[8, "M"],
+                target_cfg=[8, "M", 16],
+                normalization="batch",
+                num_classes=3,
+                number_of_fc_layers=1,
+                fc_layer_width=8,
+                input_spatial_shape=(32, 32),
+            )
+
+        with self.assertRaises(ValueError):
+            VGG(
+                cfg=[8, "M"],
+                target_cfg=[8, "M"],
+                normalization="layer",
+                num_classes=3,
+                number_of_fc_layers=1,
+                fc_layer_width=8,
+            )
+
+        self.assertEqual(
+            _reduce_growing_conv_widths((16, 16, 16), None),
+            (16, 16, 16),
+        )
+        self.assertEqual(
+            _reduce_growing_conv_widths((16, 16, 16), 0.25),
+            (16, 4, 4),
+        )
+
+        classifier_growth_model = VGG(
+            cfg=[8, "M"],
+            target_cfg=[8, "M"],
+            in_features=3,
+            normalization="batch",
+            num_classes=5,
+            number_of_fc_layers=2,
+            fc_layer_width=16,
+            initial_fc_layer_width=4,
+            input_spatial_shape=(32, 32),
+        )
+        classifier_growable = [
+            layer
+            for layer in classifier_growth_model._growable_layers
+            if isinstance(layer, LinearGrowingModule)
+        ]
+        self.assertEqual(len(classifier_growable), 1)
+        self.assertEqual(classifier_growable[0].in_features, 4)
+        self.assertEqual(classifier_growable[0].target_in_neurons, 16)
+
+    def test_growable_targets_follow_vgg_target_widths(self):
+        """Test that growable layers keep stage target widths."""
+        model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            nb_stages=3,
+            number_of_conv_per_stage=(1, 3, 3),
+            hidden_channels=(32, 64, 128),
+            number_of_fc_layers=1,
+            reduction_factor=0.125,
+        )
+
+        self.assertEqual(
+            self._stage_conv_widths(model),
+            [(32,), (64, 8, 8), (128, 16, 16)],
+        )
+        self.assertEqual(model.final_spatial_shape, (4, 4))
+        self.assertEqual(
+            self._growable_layer_targets(model),
+            [
+                ("RestrictedConv2dGrowingModule", 8, 64),
+                ("RestrictedConv2dGrowingModule", 16, 128),
+            ],
+        )
+
+        mixed_model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            nb_stages=2,
+            number_of_conv_per_stage=(3, 3),
+            hidden_channels=((24, 40, 56), (48, 80, 96)),
+            number_of_fc_layers=1,
+            reduction_factor=0.125,
+        )
+        self.assertEqual(
+            self._growable_layer_targets(mixed_model),
+            [
+                ("RestrictedConv2dGrowingModule", 5, 24),
+                ("RestrictedConv2dGrowingModule", 10, 48),
+            ],
+        )
+
+        classifier_model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            nb_stages=2,
+            number_of_conv_per_stage=1,
+            hidden_channels=(32, 64),
+            number_of_fc_layers=3,
+            fc_layer_width=32,
+            reduction_factor=0.25,
+        )
+        classifier_linears = [
+            module
+            for module in classifier_model.classifier
+            if isinstance(module, LinearGrowingModule)
+        ]
+        self.assertEqual(classifier_linears[0].out_features, 8)
+        self.assertEqual(classifier_linears[1].in_features, 8)
+        self.assertEqual(classifier_linears[1].target_in_neurons, 32)
+        self.assertEqual(classifier_linears[2].in_features, 8)
+        self.assertEqual(classifier_linears[2].target_in_neurons, 32)
+        self.assertEqual(
+            self._growable_layer_targets(classifier_model),
+            [
+                ("LinearGrowingModule", 8, 32),
+                ("LinearGrowingModule", 8, 32),
+            ],
+        )
+
+    def test_group_and_layer_normalization_forward(self):
+        """Test group and layer normalization integration in VGG."""
+        device = global_device()
+        x = torch.randn(2, 3, 32, 32, device=device)
+
+        group_model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            out_features=7,
+            nb_stages=3,
+            number_of_conv_per_stage=(1, 2, 1),
+            hidden_channels=(8, 16, 32),
+            normalization="group",
+            normalization_kwargs={"num_groups": 4, "eps": 1e-4, "affine": False},
+            reduction_factor=None,
+            device=device,
+            init_weights=False,
+        )
+        group_norm_layers = [
+            module
+            for module in group_model.modules()
+            if isinstance(module, GrowingGroupNorm)
+        ]
+        self.assertGreater(len(group_norm_layers), 0)
+        self.assertEqual(group_norm_layers[0].num_groups, 4)
+        self.assertEqual(group_norm_layers[0].eps, 1e-4)
+        self.assertFalse(group_norm_layers[0].affine)
+        self.assertShapeEqual(group_model(x), (2, 7))
+
+        layer_model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            out_features=7,
+            nb_stages=3,
+            number_of_conv_per_stage=(1, 2, 1),
+            hidden_channels=(8, 16, 32),
+            normalization="layer",
+            normalization_kwargs={
+                "eps": 1e-4,
+                "elementwise_affine": False,
+                "bias": False,
+            },
+            reduction_factor=None,
+            device=device,
+            init_weights=False,
+        )
+        layer_norm_layers = [
+            module
+            for module in layer_model.modules()
+            if isinstance(module, GrowingLayerNorm)
+        ]
+        self.assertGreater(len(layer_norm_layers), 0)
+        self.assertEqual(layer_norm_layers[0].normalized_shape, (8, 32, 32))
+        self.assertEqual(layer_norm_layers[1].normalized_shape, (16, 16, 16))
+        self.assertEqual(layer_norm_layers[2].normalized_shape, (16, 16, 16))
+        self.assertFalse(layer_norm_layers[0].elementwise_affine)
+        self.assertIsNone(layer_norm_layers[0].bias)
+        self.assertShapeEqual(layer_model(x), (2, 7))
+
+    def test_forward_backward(self):
+        """Test forward and backward passes of the initialized VGG model."""
+        model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            out_features=10,
+            nb_stages=3,
+            number_of_conv_per_stage=(1, 2, 1),
+            hidden_channels=(16, 32, 64),
+            normalization="batch",
+            device=global_device(),
+        )
+
+        x = torch.randn(4, 3, 32, 32, device=global_device())
+        output = model(x)
+        self.assertShapeEqual(output, (4, 10), "Output shape should be (4, 10)")
+        output.sum().backward()
+
+    def test_normalization_configuration_forward(self):
+        """Test forward passes with no normalization and custom BatchNorm kwargs."""
+        device = global_device()
+        x = torch.randn(2, 3, 32, 32, device=device)
+
+        with self.subTest(normalization="invalid"):
+            with self.assertRaises(ValueError):
+                init_full_vgg_structure(
+                    input_shape=(3, 32, 32),
+                    out_features=7,
+                    nb_stages=3,
+                    number_of_conv_per_stage=(1, 2, 1),
+                    hidden_channels=(8, 16, 32),
+                    normalization="invalid",  # type: ignore[arg-type]
+                    device=device,
+                )
+
+        with self.subTest(normalization="none"):
+            model_no_norm = init_full_vgg_structure(
+                input_shape=(3, 32, 32),
+                out_features=7,
+                nb_stages=3,
+                number_of_conv_per_stage=(1, 2, 1),
+                hidden_channels=(8, 16, 32),
+                normalization=None,
+                device=device,
+            )
+            norm_layers = [
+                module
+                for module in model_no_norm.modules()
+                if isinstance(module, torch.nn.BatchNorm2d)
+            ]
+            self.assertEqual(norm_layers, [])
+            self.assertShapeEqual(model_no_norm(x), (2, 7))
+
+            with self.assertRaises(ValueError):
+                init_full_vgg_structure(
+                    input_shape=(3, 32, 32),
+                    out_features=7,
+                    nb_stages=3,
+                    number_of_conv_per_stage=(1, 2, 1),
+                    hidden_channels=(8, 16, 32),
+                    normalization=None,
+                    normalization_kwargs={"eps": 1e-3},
+                    device=device,
+                )
+
+        with self.subTest(normalization="batch"):
+            normalization_kwargs: NormKwargs = {
+                "eps": 1e-3,
+                "momentum": 0.25,
+                "affine": False,
+                "track_running_stats": False,
+            }
+            model_batch_norm = init_full_vgg_structure(
+                input_shape=(3, 32, 32),
+                out_features=7,
+                nb_stages=3,
+                number_of_conv_per_stage=(1, 2, 1),
+                hidden_channels=(8, 16, 32),
+                normalization="batch",
+                normalization_kwargs=normalization_kwargs,
+                init_weights=False,
+                device=device,
+            )
+            norm_layers = [
+                module
+                for module in model_batch_norm.modules()
+                if isinstance(module, torch.nn.BatchNorm2d)
+            ]
+            self.assertGreater(len(norm_layers), 0)
+            for norm_layer in norm_layers:
+                self.assertEqual(norm_layer.eps, normalization_kwargs["eps"])
+                self.assertEqual(norm_layer.momentum, normalization_kwargs["momentum"])
+                self.assertEqual(norm_layer.affine, normalization_kwargs["affine"])
+                self.assertEqual(
+                    norm_layer.track_running_stats,
+                    normalization_kwargs["track_running_stats"],
+                )
+            self.assertShapeEqual(model_batch_norm(x), (2, 7))
+
+        with self.subTest(normalization="defaults"):
+            model_default_norm = init_full_vgg_structure(
+                input_shape=(3, 32, 32),
+                out_features=7,
+                nb_stages=3,
+                number_of_conv_per_stage=(1, 2, 1),
+                hidden_channels=(8, 16, 32),
+                normalization="batch",
+                device=device,
+            )
+            first_norm = next(
+                module
+                for module in model_default_norm.modules()
+                if isinstance(module, torch.nn.BatchNorm2d)
+            )
+            self.assertEqual(first_norm.eps, base_batch_norm_kwargs["eps"])
+            self.assertEqual(first_norm.momentum, base_batch_norm_kwargs["momentum"])
+
+    def test_extended_forward_with_layer_extensions(self):
+        """Test extended_forward and verify active extensions change the output."""
+        model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            out_features=10,
+            nb_stages=3,
+            number_of_conv_per_stage=(1, 3, 3),
+            hidden_channels=(32, 64, 128),
+            number_of_fc_layers=3,
+            fc_layer_width=64,
+            reduction_factor=0.125,
+            normalization="batch",
+            device=torch.device("cpu"),
+        )
+        model.eval()
+        x = torch.randn(2, 3, 32, 32)
+
+        output1 = model.extended_forward(x)
+        self.assertShapeEqual(output1, (2, 10))
+
+        first_growable_layer = model._growable_layers[0]
+        assert isinstance(first_growable_layer, Conv2dGrowingModule)
+        first_growable_layer.create_layer_extensions(
+            extension_size=8,
+            output_extension_init="copy_uniform",
+            input_extension_init="copy_uniform",
+        )
+
+        self.assertIsNotNone(first_growable_layer.extended_input_layer)
+        assert isinstance(first_growable_layer.previous_module, Conv2dGrowingModule)
+        self.assertIsNotNone(first_growable_layer.previous_module.extended_output_layer)
+
+        classifier_linears = [
+            module
+            for module in model.classifier
+            if isinstance(module, LinearGrowingModule)
+        ]
+        classifier_linears[0].create_layer_extensions(
+            extension_size=4,
+            output_extension_size=4,
+            input_extension_size=4 * 4 * 4,
+            output_extension_init="copy_uniform",
+            input_extension_init="copy_uniform",
+        )
+        classifier_linears[1].create_layer_extensions(
+            extension_size=4,
+            output_extension_init="copy_uniform",
+            input_extension_init="copy_uniform",
+        )
+
+        output2 = model.extended_forward(x)
+        self.assertShapeEqual(output2, (2, 10))
+        self.assertAllClose(
+            output1,
+            output2,
+            message="With scaling_factor=0, output should not change",
+        )
+
+        model.set_scaling_factor(1.0)
+        output3 = model.extended_forward(x)
+        self.assertShapeEqual(output3, (2, 10))
+        max_diff = torch.abs(output1 - output3).max().item()
+        self.assertGreater(
+            max_diff,
+            1e-4,
+            f"Outputs should differ after enabling extensions, but max diff is {max_diff}",
+        )
+
+    def test_scheduling_and_growth_bookkeeping(self):
+        """Test scheduling and growth bookkeeping without metadata refresh."""
+        model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            out_features=10,
+            nb_stages=3,
+            number_of_conv_per_stage=(1, 3, 3),
+            hidden_channels=(32, 64, 128),
+            number_of_fc_layers=1,
+            reduction_factor=0.125,
+            device=torch.device("cpu"),
+        )
+
+        feature_layer = model._feature_growing_modules[3]
+        classifier_layer = model._classifier_growing_modules[0]
+
+        model.set_growing_layers(index=0)
+        self.assertEqual(len(model._growing_layers), 1)
+        self.assertIs(model._growing_layers[0], model._growable_layers[0])
+        self.assertTrue(
+            all(layer.target_in_neurons is not None for layer in model._growable_layers)
+        )
+
+        model.init_computation()
+        self.assertTrue(feature_layer.store_input)
+        self.assertTrue(feature_layer.store_pre_activity)
+        self.assertFalse(classifier_layer.store_pre_activity)
+
+        neurons_to_add = model.number_of_neurons_to_add(number_of_growth_steps=5)
+        self.assertIsInstance(neurons_to_add, int)
+        self.assertGreater(neurons_to_add, 0)
+
+        model.set_growing_layers(scheduling_method="all")
+        with self.assertRaises(RuntimeError):
+            model.number_of_neurons_to_add(number_of_growth_steps=2)
+
+        model.set_growing_layers(scheduling_method="sequential", index=0)
+        model.currently_updated_layer_index = 0
+        missing = model.missing_neurons()
+        self.assertIsInstance(missing, int)
+        self.assertGreater(missing, 0)
+
+        plain_conv_model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            out_features=10,
+            nb_stages=2,
+            number_of_conv_per_stage=(1, 3),
+            hidden_channels=(16, 32),
+            number_of_fc_layers=1,
+            reduction_factor=0.5,
+            growing_conv_type=Conv2dGrowingModule,
+        )
+        plain_conv_model.set_growing_layers(scheduling_method="all")
+        self.assertGreater(len(plain_conv_model._growing_layers), 0)
+
+    def test_first_order_improvement_and_complete_growth(self):
+        """Test VGG growth metrics and completing growth to target widths."""
+        model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            out_features=10,
+            nb_stages=3,
+            number_of_conv_per_stage=(1, 3, 3),
+            hidden_channels=(32, 64, 128),
+            number_of_fc_layers=1,
+            reduction_factor=0.125,
+            device=torch.device("cpu"),
+        )
+
+        layer = model._growable_layers[0]
+        assert isinstance(layer, Conv2dGrowingModule)
+        update_decrease = 1.0
+        eigenvalues = [10.0, 5.0]
+        layer.parameter_update_decrease = torch.tensor(update_decrease)
+        layer.eigenvalues_extension = torch.tensor(eigenvalues)
+
+        improvement = layer.first_order_improvement
+        self.assertIsInstance(improvement.item(), float)
+        self.assertAlmostEqual(
+            improvement.item(),
+            update_decrease + sum(x**2 for x in eigenvalues),
+        )
+
+        initial_missing = layer.missing_neurons()
+        self.assertGreater(initial_missing, 0)
+        initial_in_neurons = layer.in_neurons
+
+        model.complete_growth(
+            extension_kwargs={
+                "output_extension_init": "zeros",
+                "input_extension_init": "zeros",
+            }
+        )
+
+        self.assertGreater(layer.in_neurons, initial_in_neurons)
+        self.assertEqual(layer.missing_neurons(), 0)
+
+        model.set_growing_layers(scheduling_method="all")
+        self.assertTrue(
+            all(
+                growable_layer.missing_neurons() == 0
+                for growable_layer in model._growable_layers
+            )
+        )
+
+    def test_initialize_weights_handles_conv_without_bias(self):
+        """Test the conv initialization branch when a convolution has no bias."""
+        model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            out_features=10,
+            nb_stages=2,
+            number_of_conv_per_stage=(1, 2),
+            hidden_channels=(8, 16),
+            number_of_fc_layers=1,
+            init_weights=False,
+        )
+        first_conv = self._first_conv(model)
+        first_conv.bias = None
+        model._initialize_weights()
+        self.assertIsNone(first_conv.bias)
+
+    def test_initialize_weights_handles_norms_without_weight_or_bias(self):
+        """Test normalization init branches when affine weights or biases are absent."""
+        group_model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            out_features=10,
+            nb_stages=2,
+            number_of_conv_per_stage=(1, 1),
+            hidden_channels=(8, 16),
+            normalization="group",
+            normalization_kwargs={"num_groups": 1, "affine": False},
+            init_weights=False,
+        )
+        group_norm = next(
+            module
+            for module in group_model.modules()
+            if isinstance(module, GrowingGroupNorm)
+        )
+        self.assertIsNone(group_norm.weight)
+        self.assertIsNone(group_norm.bias)
+        group_model._initialize_weights()
+
+        layer_model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            out_features=10,
+            nb_stages=2,
+            number_of_conv_per_stage=(1, 1),
+            hidden_channels=(8, 16),
+            normalization="layer",
+            normalization_kwargs={"elementwise_affine": True, "bias": False},
+            init_weights=False,
+        )
+        layer_norm = next(
+            module
+            for module in layer_model.modules()
+            if isinstance(module, GrowingLayerNorm)
+        )
+        self.assertIsNotNone(layer_norm.weight)
+        self.assertIsNone(layer_norm.bias)
+        layer_model._initialize_weights()
+
+    def test_custom_activation_and_classifier_configuration(self):
+        """Test custom activation wiring and configurable classifier layout."""
+        model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            out_features=11,
+            nb_stages=3,
+            number_of_conv_per_stage=1,
+            hidden_channels=(8, 16, 32),
+            normalization="batch",
+            activation=nn.LeakyReLU(negative_slope=0.2),
+            number_of_fc_layers=4,
+            fc_layer_width=128,
+        )
+
+        activations = [
+            module for module in model.modules() if isinstance(module, nn.LeakyReLU)
+        ]
+        self.assertGreater(len(activations), 0)
+
+        classifier_linears = [
+            module
+            for module in model.classifier
+            if isinstance(module, LinearGrowingModule)
+        ]
+        classifier_dropouts = [
+            module for module in model.classifier if isinstance(module, nn.Dropout)
+        ]
+        self.assertEqual(len(classifier_linears), 4)
+        self.assertEqual(len(classifier_dropouts), 3)
+
+        self.assertEqual(model.final_spatial_shape, (4, 4))
+        self.assertEqual(classifier_linears[0].in_features, 32 * 4 * 4)
+        self.assertEqual(classifier_linears[0].out_features, 4)
+        self.assertEqual(classifier_linears[1].in_features, 4)
+        self.assertEqual(classifier_linears[1].out_features, 4)
+        self.assertEqual(classifier_linears[1].target_in_neurons, 128)
+        self.assertEqual(classifier_linears[2].in_features, 4)
+        self.assertEqual(classifier_linears[2].out_features, 4)
+        self.assertEqual(classifier_linears[2].target_in_neurons, 128)
+        self.assertEqual(classifier_linears[3].in_features, 4)
+        self.assertEqual(classifier_linears[3].out_features, 11)
+        self.assertEqual(classifier_linears[3].target_in_neurons, 128)
+
+        single_fc_model = init_full_vgg_structure(
+            input_shape=(3, 32, 32),
+            out_features=11,
+            nb_stages=3,
+            number_of_conv_per_stage=1,
+            hidden_channels=(8, 16, 32),
+            number_of_fc_layers=1,
+            fc_layer_width=128,
+        )
+        single_fc_linears = [
+            module
+            for module in single_fc_model.classifier
+            if isinstance(module, LinearGrowingModule)
+        ]
+        single_fc_dropouts = [
+            module
+            for module in single_fc_model.classifier
+            if isinstance(module, nn.Dropout)
+        ]
+        self.assertEqual(len(single_fc_linears), 1)
+        self.assertEqual(len(single_fc_dropouts), 0)
+        self.assertEqual(single_fc_model.final_spatial_shape, (4, 4))
+        self.assertEqual(single_fc_linears[0].in_features, 32 * 4 * 4)
+        self.assertEqual(single_fc_linears[0].out_features, 11)
+
+        x = torch.randn(2, 3, 32, 32)
+        output = model(x)
+        self.assertShapeEqual(output, (2, 11))

--- a/tests/test_vgg.py
+++ b/tests/test_vgg.py
@@ -1143,6 +1143,6 @@ class TestVGG(TorchTestCase):
         self.assertEqual(single_fc_linears[0].in_features, 32 * 4 * 4)
         self.assertEqual(single_fc_linears[0].out_features, 11)
 
-        x = torch.randn(2, 3, 32, 32)
+        x = torch.randn(2, 3, 32, 32, device=model.device)
         output = model(x)
         self.assertShapeEqual(output, (2, 11))

--- a/tests/test_vgg.py
+++ b/tests/test_vgg.py
@@ -9,7 +9,7 @@ from gromo.containers.vgg import (
     VGG,
     NormKwargs,
     _reduce_growing_conv_widths,
-    base_batch_norm_kwargs,
+    base_norm_kwargs,
     init_full_vgg_structure,
 )
 from gromo.modules.conv2d_growing_module import Conv2dGrowingModule
@@ -454,22 +454,19 @@ class TestVGG(TorchTestCase):
         post_conv_layers = model._build_post_conv_layers(4, (32, 32))
         self.assertIsInstance(post_conv_layers, nn.Sequential)
 
-        model._update_batch_norm_kwargs({"momentum": 0.25})
-        self.assertEqual(model.batch_norm_kwargs["momentum"], 0.25)
-        with self.assertRaises(ValueError):
-            model._update_batch_norm_kwargs({"unknown": 1.0})  # type: ignore[arg-type]
+        model._update_normalization_kwargs({"momentum": 0.25})
+        self.assertEqual(model.normalization_kwargs["momentum"], 0.25)
+        model._update_normalization_kwargs({"unknown": 1.0})  # type: ignore[arg-type]
 
         model.normalization = "group"
-        model._update_group_norm_kwargs({"num_groups": 4})
-        self.assertEqual(model.group_norm_kwargs["num_groups"], 4)
-        with self.assertRaises(ValueError):
-            model._update_group_norm_kwargs({"momentum": 0.1})  # type: ignore[arg-type]
+        model._update_normalization_kwargs({"num_groups": 4, "momentum": 0.1})
+        self.assertEqual(model.normalization_kwargs["num_groups"], 4)
+        self.assertEqual(model.normalization_kwargs["momentum"], 0.1)
 
         model.normalization = "layer"
-        model._update_layer_norm_kwargs({"bias": False})
-        self.assertFalse(model.layer_norm_kwargs["bias"])
-        with self.assertRaises(ValueError):
-            model._update_layer_norm_kwargs({"affine": False})  # type: ignore[arg-type]
+        model._update_normalization_kwargs({"bias": False})
+        self.assertFalse(model.normalization_kwargs["bias"])
+        model._update_normalization_kwargs({"unknown_layer_key": False})  # type: ignore[arg-type]
 
         layer_norm = model._build_growing_normalization(4, (32, 32))
         self.assertIsInstance(layer_norm, GrowingLayerNorm)
@@ -496,17 +493,17 @@ class TestVGG(TorchTestCase):
                 input_spatial_shape=(32, 32),
             )
 
-        with self.assertRaises(ValueError):
-            VGG(
-                cfg=[8, "M"],
-                target_cfg=[8, "M"],
-                normalization=None,
-                normalization_kwargs={"eps": 1e-4},
-                num_classes=3,
-                number_of_fc_layers=1,
-                fc_layer_width=8,
-                input_spatial_shape=(32, 32),
-            )
+        none_norm_model = VGG(
+            cfg=[8, "M"],
+            target_cfg=[8, "M"],
+            normalization=None,
+            normalization_kwargs={"eps": 1e-4},
+            num_classes=3,
+            number_of_fc_layers=1,
+            fc_layer_width=8,
+            input_spatial_shape=(32, 32),
+        )
+        self.assertEqual(none_norm_model.normalization_kwargs["eps"], 1e-4)
 
         with self.assertRaises(ValueError):
             VGG(
@@ -771,17 +768,17 @@ class TestVGG(TorchTestCase):
             self.assertEqual(norm_layers, [])
             self.assertShapeEqual(model_no_norm(x), (2, 7))
 
-            with self.assertRaises(ValueError):
-                init_full_vgg_structure(
-                    input_shape=(3, 32, 32),
-                    out_features=7,
-                    nb_stages=3,
-                    number_of_conv_per_stage=(1, 2, 1),
-                    hidden_channels=(8, 16, 32),
-                    normalization=None,
-                    normalization_kwargs={"eps": 1e-3},
-                    device=device,
-                )
+            model_no_norm_with_kwargs = init_full_vgg_structure(
+                input_shape=(3, 32, 32),
+                out_features=7,
+                nb_stages=3,
+                number_of_conv_per_stage=(1, 2, 1),
+                hidden_channels=(8, 16, 32),
+                normalization=None,
+                normalization_kwargs={"eps": 1e-3},
+                device=device,
+            )
+            self.assertEqual(model_no_norm_with_kwargs.normalization_kwargs["eps"], 1e-3)
 
         with self.subTest(normalization="batch"):
             normalization_kwargs: NormKwargs = {
@@ -832,8 +829,8 @@ class TestVGG(TorchTestCase):
                 for module in model_default_norm.modules()
                 if isinstance(module, torch.nn.BatchNorm2d)
             )
-            self.assertEqual(first_norm.eps, base_batch_norm_kwargs["eps"])
-            self.assertEqual(first_norm.momentum, base_batch_norm_kwargs["momentum"])
+            self.assertEqual(first_norm.eps, base_norm_kwargs["eps"])
+            self.assertEqual(first_norm.momentum, base_norm_kwargs["momentum"])
 
     def test_extended_forward_with_layer_extensions(self):
         """Test extended_forward and verify active extensions change the output."""

--- a/tests/test_vgg.py
+++ b/tests/test_vgg.py
@@ -285,6 +285,7 @@ class TestVGG(TorchTestCase):
     @unittest.skipUnless(HAS_TORCHVISION, "torchvision is not installed")
     def test_torchvision_vgg11_parity(self):
         """Temporary parity check against torchvision VGG11."""
+        device = global_device()
         model = init_full_vgg_structure(
             input_shape=(3, 224, 224),
             out_features=1000,
@@ -295,7 +296,7 @@ class TestVGG(TorchTestCase):
             fc_layer_width=4096,
             reduction_factor=None,
         )
-        reference = vgg11(weights=None)
+        reference = vgg11(weights=None).to(device)
         self._copy_torchvision_vgg_weights(reference, model)
         model.eval()
         reference.eval()
@@ -319,7 +320,7 @@ class TestVGG(TorchTestCase):
             sum(parameter.numel() for parameter in reference.parameters()),
         )
 
-        x = torch.randn(2, 3, 224, 224)
+        x = torch.randn(2, 3, 224, 224, device=device)
         model_output = model(x)
         reference_output = reference(x)
         self.assertShapeEqual(model_output, reference_output.shape)
@@ -328,6 +329,7 @@ class TestVGG(TorchTestCase):
     @unittest.skipUnless(HAS_TORCHVISION, "torchvision is not installed")
     def test_torchvision_vgg11_bn_parity(self):
         """Temporary parity check against torchvision VGG11 with batch norm."""
+        device = global_device()
         model = init_full_vgg_structure(
             input_shape=(3, 224, 224),
             out_features=1000,
@@ -338,7 +340,7 @@ class TestVGG(TorchTestCase):
             fc_layer_width=4096,
             reduction_factor=None,
         )
-        reference = vgg11_bn(weights=None)
+        reference = vgg11_bn(weights=None).to(device)
         self._copy_torchvision_vgg_weights(reference, model)
         model.eval()
         reference.eval()
@@ -353,7 +355,7 @@ class TestVGG(TorchTestCase):
             sum(parameter.numel() for parameter in reference.parameters()),
         )
 
-        x = torch.randn(2, 3, 224, 224)
+        x = torch.randn(2, 3, 224, 224, device=device)
         model_output = model(x)
         reference_output = reference(x)
         self.assertShapeEqual(model_output, reference_output.shape)


### PR DESCRIPTION
## Summary

This PR adds a configurable growable VGG container `class VGG(SequentialGrowingModel)`, following the
VGG family introduced in:

Simonyan, K. and Zisserman, A. (2015).
*Very Deep Convolutional Networks for Large-Scale Image Recognition*.
ICLR 2015.
https://arxiv.org/abs/1409.1556

## Stage Architecture
With r = reduction_factor, C_(i-1) and C_i denote the number of channels in the previous and current stage, respectively.
The activation and normalization functions are not shown for clarity.
```mermaid
flowchart LR
    X["Stage Input<br/>shape = C_(i-1), H_(i-1), W_(i-1)"]
    C1["conv2d_growing_module<br/>allow_growing = false"]
    C2["conv2d_growing_module<br/>allow_growing = true"]
    D["..."]
    CN["conv2d_growing_module<br/>allow_growing = true"]
    P["MaxPool"]
    Y["Stage Output<br/>shape = C_i, ⌊H_(i-1)/2⌋, ⌊W_(i-1)/2⌋"]

    X -->|"C_(i-1), H_(i-1), W_(i-1)"| C1
    C1 -->|"r*C_i, H_(i-1), W_(i-1)"| C2
    C2 -->|"r*C_i, H_(i-1), W_(i-1)"| D
    D -->|"r*C_i, H_(i-1), W_(i-1)"| CN
    CN -->|"C_i, H_(i-1), W_(i-1)"| P
    P -->|"C_i, ⌊H_(i-1)/2⌋, ⌊W_(i-1)/2⌋"| Y
```

## Full Architecture


```mermaid
flowchart LR
    X["Input<br/>shape: C_in × H × W"]
    S1["Stage S_1<br/>conv blocks + maxpool"]
    SD["..."]
    SN["Stage S_N<br/>conv blocks + maxpool"]
    A["AdaptiveAvgPool2d<br/>shape: C_N × F_h × F_w"]
    FL["Flatten<br/>shape: C_N * F_h * F_w"]
    FC1["LinearGrowingModule 1<br/>allow_growing = false + Dropout"]
    FC2["LinearGrowingModule 2<br/>+ Dropout"]
    DOD["..."]
    FCK["Final LinearGrowingModule"]
    Y["Output<br/>shape: num_classes"]

    X --> S1
    S1 --> SD
    SD --> SN
    SN --> A
    A --> FL
    FL --> FC1
    FC1 --> FC2
    FC2 --> DOD
    DOD --> FCK
    FCK --> Y

```

## Features

- configurable stage structure through `number_of_conv_per_stage`
- configurable target widths through `hidden_channels`
- configurable classifier depth and width
- support for `batch`, `group`, `layer`, or no normalization
- reduced initialization of growable layers through `reduction_factor`

## Inputs And Growth Parameters

Main constructor inputs include:
- `input_shape`: input tensor shape `(C, H, W)`
- `hidden_channels`: per-stage target widths, optionally per-convolution
- `number_of_conv_per_stage`: number of convolutions in each stage
- `number_of_fc_layers`: number of classifier layers
- `fc_layer_width`: target hidden width of classifier layers
- `reduction_factor`: initial width reduction for growable layers
- `normalization`: `batch`, `group`, or `None`