### PR TITLE
!fix: Fix the stride in the second layer

### DIFF
--- a/src/gromo/containers/resnet.py
+++ b/src/gromo/containers/resnet.py
@@ -53,6 +53,9 @@ class ResNetBasicBlock(SequentialGrowingModel):
         If True, adapt the network for small input images (e.g., CIFAR-10/100).
         This uses smaller kernels, no stride, and
         no max pooling in the initial layers.
+    skip_first_downsample : bool
+        If True, the first block of the second stage will not perform spatial
+        downsampling (stride=1 instead of 2).
     inplanes : int
         Number of initial planes (channels) after the first convolution.
         (Default is 64 as in standard ResNet architectures.)
@@ -85,6 +88,7 @@ class ResNetBasicBlock(SequentialGrowingModel):
         output_block_kernel_size: int = 3,
         hidden_channels: tuple[int, ...] = (0, 0, 0, 0),
         small_inputs: bool = False,
+        skip_first_downsample: bool = False,
         inplanes: int = 64,
         use_preactivation: bool = True,
         normalization: ResNetNormalizationType | None = "batch",
@@ -117,10 +121,8 @@ class ResNetBasicBlock(SequentialGrowingModel):
             output_channels = inplanes * (2**i)
             stage_hidden_channels = hidden_channels[i]
 
-            # For small inputs, adjust stride behavior
-            stage_stride = 2 if (i > 0 and not (small_inputs and i == 1)) else 1
-            if small_inputs and i == 1:
-                stage_stride = 1
+            # adjust stride behavior
+            stage_stride = 1 if (i == 0 or (skip_first_downsample and i == 1)) else 2
 
             stage = nn.Sequential()
             block = self._create_block(
@@ -615,6 +617,7 @@ def init_full_resnet_structure(
     reduction_factor: float = 1 / 64,
     hidden_channels: tuple[int | tuple[int, ...], ...] | None = None,
     small_inputs: bool | None = None,
+    skip_first_downsample: bool | None = None,
     number_of_blocks_per_stage: int | tuple[int, ...] = 2,
     inplanes: int = 64,
     nb_stages: int = 4,
@@ -660,6 +663,9 @@ def init_full_resnet_structure(
     small_inputs : bool | None
         If True, adapt the network for small input images (e.g., CIFAR-10/100).
         This uses smaller kernels, no stride, and no max pooling in the initial layers.
+    skip_first_downsample : bool | None
+        If True, skip the first downsampling operation of the second stage.
+        If None, it will be set to `small_inputs` (i.e., skip downsampling for small inputs).
     number_of_blocks_per_stage : int | tuple[int, ...]
         Number of basic blocks per stage. If an integer is provided, the same number
         of blocks will be used for all stages. If a tuple is provided, it should
@@ -710,6 +716,8 @@ def init_full_resnet_structure(
         in_features = input_shape[0]
     if small_inputs is None:
         small_inputs = input_shape[1] <= 32 and input_shape[2] <= 32
+    if skip_first_downsample is None:
+        skip_first_downsample = small_inputs
 
     # Normalize number_of_blocks_per_stage to a tuple
     if isinstance(number_of_blocks_per_stage, int):
@@ -772,6 +780,7 @@ def init_full_resnet_structure(
         output_block_kernel_size=output_block_kernel_size,
         hidden_channels=initial_hidden_channels,
         small_inputs=small_inputs,
+        skip_first_downsample=skip_first_downsample,
         inplanes=inplanes,
         use_preactivation=use_preactivation,
         normalization=normalization,
@@ -863,3 +872,19 @@ if __name__ == "__main__":
         ]
         print(f"  Stage {i}: {block_hidden}")
     summary(model_custom, input_size=(1, 3, 224, 224))
+
+    resnet20 = init_full_resnet_structure(
+        input_shape=(3, 32, 32),
+        out_features=10,
+        reduction_factor=1,
+        number_of_blocks_per_stage=3,
+        nb_stages=3,
+        inplanes=16,
+        use_preactivation=False,
+        skip_first_downsample=False,  # ResNet-20 for CIFAR-10 does not skip the first downsample
+    )
+    print("\n" + "=" * 60)
+    print("ResNet-20 for CIFAR-10")
+    print("=" * 60)
+    print(resnet20)
+    summary(resnet20, input_size=(1, 3, 32, 32))

--- a/tests/test_resnet.py
+++ b/tests/test_resnet.py
@@ -169,6 +169,118 @@ class TestResNet(TorchTestCase):
                 number_of_blocks_per_stage=2,
             )
 
+    def test_stage2_first_block_stride_with_skip_first_downsample(
+        self,
+        use_preactivation: bool = True,
+    ):
+        """Test stage-2 first-block stride and spatial size with explicit skip policy."""
+        device = global_device()
+
+        def get_stage2_stride_and_output_size(
+            model: ResNetBasicBlock,
+            input_hw: int,
+        ) -> tuple[tuple[int, int], tuple[int, int]]:
+            stage2_first_block = model.stages[1][0]  # type: ignore[index]
+            stride = stage2_first_block.first_layer.layer.stride  # type: ignore[attr-defined]
+
+            x = torch.randn(2, 3, input_hw, input_hw, device=device)
+            x = model.pre_net(x)
+            x = model.stages[0](x)
+            x = stage2_first_block(x)
+            output_size = x.shape[-2:]
+            return stride, output_size
+
+        model_skip = init_full_resnet_structure(
+            input_shape=(3, 8, 8),
+            out_features=10,
+            number_of_blocks_per_stage=1,
+            nb_stages=2,
+            inplanes=1,
+            use_preactivation=use_preactivation,
+            small_inputs=True,
+            skip_first_downsample=True,
+            device=device,
+        )
+        stride_skip, output_size_skip = get_stage2_stride_and_output_size(model_skip, 8)
+        self.assertEqual(stride_skip, (1, 1))
+        self.assertEqual(output_size_skip, (8, 8))
+
+        model_downsample = init_full_resnet_structure(
+            input_shape=(3, 8, 8),
+            out_features=10,
+            number_of_blocks_per_stage=1,
+            nb_stages=2,
+            inplanes=1,
+            use_preactivation=use_preactivation,
+            small_inputs=True,
+            skip_first_downsample=False,
+            device=device,
+        )
+        stride_downsample, output_size_downsample = get_stage2_stride_and_output_size(
+            model_downsample,
+            8,
+        )
+
+        self.assertEqual(stride_downsample, (2, 2))
+        self.assertEqual(output_size_downsample, (4, 4))
+
+    def test_stage2_first_block_stride_default_skip_first_downsample(
+        self,
+        use_preactivation: bool = True,
+    ):
+        """Test default skip_first_downsample behavior inferred from input size."""
+        device = global_device()
+
+        def get_stage2_stride_and_output_size(
+            model: ResNetBasicBlock,
+            input_hw: int,
+        ) -> tuple[tuple[int, int], tuple[int, int]]:
+            stage2_first_block = model.stages[1][0]  # type: ignore[index]
+            stride = stage2_first_block.first_layer.layer.stride  # type: ignore[attr-defined]
+
+            x = torch.randn(2, 3, input_hw, input_hw, device=device)
+            x = model.pre_net(x)
+            x = model.stages[0](x)
+            x = stage2_first_block(x)
+            output_size = x.shape[-2:]
+            return stride, output_size
+
+        model_small_default = init_full_resnet_structure(
+            input_shape=(3, 8, 8),
+            out_features=10,
+            number_of_blocks_per_stage=1,
+            nb_stages=2,
+            inplanes=1,
+            use_preactivation=use_preactivation,
+            device=device,
+        )
+        small_stride, small_output_size = get_stage2_stride_and_output_size(
+            model_small_default,
+            8,
+        )
+
+        self.assertTrue(model_small_default.small_inputs)
+        self.assertEqual(small_stride, (1, 1))
+        self.assertEqual(small_output_size, (8, 8))
+
+        model_large_default = init_full_resnet_structure(
+            input_shape=(3, 64, 64),
+            out_features=10,
+            number_of_blocks_per_stage=1,
+            nb_stages=2,
+            inplanes=1,
+            use_preactivation=use_preactivation,
+            device=device,
+        )
+        large_stride, large_output_size = get_stage2_stride_and_output_size(
+            model_large_default,
+            64,
+        )
+
+        self.assertFalse(model_large_default.small_inputs)
+        self.assertEqual(large_stride, (2, 2))
+        self.assertEqual(large_output_size, (8, 8))
+
     @unittest_parametrize(({"use_preactivation": True}, {"use_preactivation": False}))
     def test_forward_backward(self, use_preactivation: bool = True):
         """Test forward and backward pass of the ResNet model."""


### PR DESCRIPTION
For some reason, when I coded the ResNet class I put stride=1 on the second stage in the case of a `small_inputs` ResNet. This is not a bad choice in itself but it does not align with what is done in ResNet20 for examples.
We should add an option to be able to create ResNet20.
I chose to  have the stride 1 on second stage as default behavior for `small_inputs` .

For ResNet20 the `skip_first_downsample=False` need to be explicitly added.