### PR TITLE
fix: Made the code compatible with default torch LR scheduler

### DIFF
--- a/src/gromo/utils/training_utils.py
+++ b/src/gromo/utils/training_utils.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Generator
-from typing import Any
+from typing import Any, Literal
 
 import torch
 import torch.utils.data
@@ -245,8 +245,7 @@ def gradient_descent(
     batch_limit: int | None = None,
     dataloader_seed: int | None = None,
     device: torch.device = torch.device("cpu"),
-    scheduler_step_after_epoch: bool = True,
-    scheduler_step_after_batch: bool = False,
+    scheduler_step_granularity: Literal["epoch", "batch"] = "epoch",
 ) -> tuple[float, float]:
     """
     Train the model on the train_dataloader using classic gradient descent.
@@ -274,10 +273,8 @@ def gradient_descent(
         Default is None.
     device : torch.device, optional
         Device to use. Default is torch.device("cpu").
-    scheduler_step_after_epoch : bool, optional
-        Whether to step the scheduler after each epoch. Default is True.
-    scheduler_step_after_batch : bool, optional
-        Whether to step the scheduler after each batch. Default is False.
+    scheduler_step_granularity : Literal["epoch", "batch"], optional
+        Whether to step the scheduler after each epoch (`"epoch"`, default) or each mini-batch (`"batch"`).
 
     Returns
     -------
@@ -318,10 +315,10 @@ def gradient_descent(
         loss_meter.update(loss.detach(), x.size(0))
         metrics.update(y_pred.detach(), y)
 
-        if scheduler is not None and scheduler_step_after_batch:
+        if scheduler is not None and scheduler_step_granularity == "batch":
             scheduler.step()
 
-    if scheduler is not None and scheduler_step_after_epoch:
+    if scheduler is not None and scheduler_step_granularity == "epoch":
         scheduler.step()
 
     return loss_meter.compute().item(), metrics.compute().item()

--- a/src/gromo/utils/training_utils.py
+++ b/src/gromo/utils/training_utils.py
@@ -239,12 +239,14 @@ def gradient_descent(
     model: nn.Module,
     train_dataloader: torch.utils.data.DataLoader,
     optimizer: torch.optim.Optimizer,
-    scheduler: Any | None,
+    scheduler: torch.optim.lr_scheduler.LRScheduler | None,
     loss_function: nn.Module,
     metrics: Metric | None = None,
     batch_limit: int | None = None,
     dataloader_seed: int | None = None,
     device: torch.device = torch.device("cpu"),
+    scheduler_step_after_epoch: bool = True,
+    scheduler_step_after_batch: bool = False,
 ) -> tuple[float, float]:
     """
     Train the model on the train_dataloader using classic gradient descent.
@@ -257,7 +259,7 @@ def gradient_descent(
         The dataloader for training data.
     optimizer : torch.optim.Optimizer
         The optimizer to use.
-    scheduler : Any | None, optional
+    scheduler : torch.optim.lr_scheduler.LRScheduler | None, optional
         Learning rate scheduler. Default is None.
     loss_function : nn.Module
         The loss function to use. Must have reduction="mean".
@@ -272,6 +274,10 @@ def gradient_descent(
         Default is None.
     device : torch.device, optional
         Device to use. Default is torch.device("cpu").
+    scheduler_step_after_epoch : bool, optional
+        Whether to step the scheduler after each epoch. Default is True.
+    scheduler_step_after_batch : bool, optional
+        Whether to step the scheduler after each batch. Default is False.
 
     Returns
     -------
@@ -307,15 +313,16 @@ def gradient_descent(
 
         loss.backward()
         optimizer.step()
-        if scheduler is not None:
-            scheduler.step()
 
         # update metrics
         loss_meter.update(loss.detach(), x.size(0))
         metrics.update(y_pred.detach(), y)
 
-    if scheduler is not None and hasattr(scheduler, "epoch_step"):
-        scheduler.epoch_step()
+        if scheduler is not None and scheduler_step_after_batch:
+            scheduler.step()
+
+    if scheduler is not None and scheduler_step_after_epoch:
+        scheduler.step()
 
     return loss_meter.compute().item(), metrics.compute().item()
 

--- a/tests/test_training_utils.py
+++ b/tests/test_training_utils.py
@@ -248,20 +248,16 @@ class TestEvaluateModel(TorchTestCase):
             )
 
 
-class _FakeScheduler:
+class _FakeScheduler(torch.optim.lr_scheduler.LRScheduler):
     """Minimal scheduler double that records step/epoch_step calls."""
 
     def __init__(self):
         self.step_count = 0
         self.epoch_step_count = 0
 
-    def step(self):
+    def step(self):  # type: ignore
         """Record a step call."""
         self.step_count += 1
-
-    def epoch_step(self):
-        """Record an epoch_step call."""
-        self.epoch_step_count += 1
 
 
 class TestGradientDescent(TorchTestCase):
@@ -318,16 +314,31 @@ class TestGradientDescent(TorchTestCase):
         model = _SimpleModel(4, 2)
         dl = self._make_dataloader(n_samples=8, batch_size=4)  # 2 batches
         optimizer = torch.optim.SGD(model.parameters(), lr=0.01)
-        scheduler = _FakeScheduler()
-        gradient_descent(
-            model,
-            dl,
-            optimizer,
-            scheduler=scheduler,
-            loss_function=nn.MSELoss(reduction="mean"),
-        )
-        self.assertEqual(scheduler.step_count, 2)
-        self.assertEqual(scheduler.epoch_step_count, 1)
+        with self.subTest("after_batch"):
+            scheduler = _FakeScheduler()
+            gradient_descent(
+                model,
+                dl,
+                optimizer,
+                scheduler=scheduler,
+                loss_function=nn.MSELoss(reduction="mean"),
+                scheduler_step_after_batch=True,
+                scheduler_step_after_epoch=False,
+            )
+            self.assertEqual(scheduler.step_count, 2)
+
+        with self.subTest("after_epoch"):
+            scheduler = _FakeScheduler()
+            gradient_descent(
+                model,
+                dl,
+                optimizer,
+                scheduler=scheduler,
+                loss_function=nn.MSELoss(reduction="mean"),
+                scheduler_step_after_batch=False,
+                scheduler_step_after_epoch=True,
+            )
+            self.assertEqual(scheduler.step_count, 1)
 
     def test_loss_decreases(self):
         """Loss after training is lower than before."""

--- a/tests/test_training_utils.py
+++ b/tests/test_training_utils.py
@@ -322,8 +322,7 @@ class TestGradientDescent(TorchTestCase):
                 optimizer,
                 scheduler=scheduler,
                 loss_function=nn.MSELoss(reduction="mean"),
-                scheduler_step_after_batch=True,
-                scheduler_step_after_epoch=False,
+                scheduler_step_granularity="batch",
             )
             self.assertEqual(scheduler.step_count, 2)
 
@@ -335,8 +334,7 @@ class TestGradientDescent(TorchTestCase):
                 optimizer,
                 scheduler=scheduler,
                 loss_function=nn.MSELoss(reduction="mean"),
-                scheduler_step_after_batch=False,
-                scheduler_step_after_epoch=True,
+                scheduler_step_granularity="epoch",
             )
             self.assertEqual(scheduler.step_count, 1)
 


### PR DESCRIPTION
For now we were using custom LR scheduler. I chose to go for classical pytorch LR schedulers. This require only calling step every epoch. However some LR scheduler could require a call to step every batch.

As a consquence I introduced new options to do step either every epoch (default value) or every batch.