### PR TITLE
enh: Introduce the match_extending_layer normalization

### DIFF
--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -2872,8 +2872,7 @@ class GrowingModule(torch.nn.Module):
         normalization_type : str
             type of normalization to use, one of 'equalize_second_layer',
             'equalize_extensions', 'match_extending_layer', 'weird_normalization',
-            'legacy_normalization'
-            'gradmax_normalization'
+            'legacy_normalization', 'gradmax_normalization'
         gradmax_scale : float
             For ``gradmax_normalization`` only: scalar :math:`s` in :math:`c = s \\cdot \\text{mean}(\\|W_i\\|)`.
             Must be positive. Default ``1.0``.
@@ -3059,7 +3058,7 @@ class GrowingModule(torch.nn.Module):
             input_extension_scale = _scale_to(self.extended_input_layer, std_target)
             output_extension_scale = delta_scale / input_extension_scale
         elif normalization_type == "match_extending_layer":
-            if self.previous_module is None or not hasattr(self.previous_module, "layer"):
+            if not isinstance(self.previous_module, GrowingModule):
                 raise ValueError(
                     "match_extending_layer requires a previous GrowingModule "
                     "with a .layer attribute."
@@ -3073,8 +3072,10 @@ class GrowingModule(torch.nn.Module):
             if self_std is None and self.extended_input_layer is not None:
                 self_std = self.get_fan_in_from_layer(self.extended_input_layer) ** -0.5
             prev_std = _std_of_layer(self.previous_module.layer)
+            assert isinstance(self_std, float), f"{type(self_std)} is not float"
             if prev_std is None and prev_ext is not None:
                 prev_std = self.get_fan_in_from_layer(prev_ext) ** -0.5
+            assert isinstance(prev_std, float), f"{type(prev_std)} is not float"
             input_extension_scale = _scale_to(self.extended_input_layer, self_std)
             output_extension_scale = _scale_to(prev_ext, prev_std)
             delta_scale = _scale_to(self.optimal_delta_layer, self_std)

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -2835,6 +2835,20 @@ class GrowingModule(torch.nn.Module):
         - optimal_delta_layer is scaled to match the scaling of the extended_input_layer
         and the extended_output_layer
         (so by s ** 2 / (std(extended_input_layer) * std(extended_output_layer)))
+        Note that the goal here is to give both extensions the same scale; for the
+        output extension this is not the std of the layer it extends (that layer
+        belongs to ``self.previous_module``), so the result is *not* scale-matched
+        to the target layer. Use "match_extending_layer" for that behaviour.
+
+        If normalization_type is "match_extending_layer":
+        Each update component is scaled to match the std of the layer it modifies:
+        - extended_input_layer is scaled to std(self.layer.weight)
+        - previous_module.extended_output_layer is scaled to
+        std(previous_module.layer.weight)
+        - optimal_delta_layer is scaled to std(self.layer.weight)
+        In this mode ``std_target`` is ignored; each component uses the std of its
+        target layer. A previous GrowingModule with a ``.layer`` exposing weights
+        is required.
 
         If normalization_type is "gradmax_normalization":
         Let ``gradmax_scale`` be :math:`s` (default 1). Let :math:`c = s \cdot \text{mean}_i \|W_i\|`
@@ -2853,11 +2867,12 @@ class GrowingModule(torch.nn.Module):
         Parameters
         ----------
         std_target : float | None
-            target standard deviation for the weights of the updates
+            target standard deviation for the weights of the updates. Ignored
+            when ``normalization_type == "match_extending_layer"``.
         normalization_type : str
-            type of normalization to use, one of
-            'equalize_second_layer', 'equalize_extensions',
-            'weird_normalization', 'legacy_normalization',
+            type of normalization to use, one of 'equalize_second_layer',
+            'equalize_extensions', 'match_extending_layer', 'weird_normalization',
+            'legacy_normalization'
             'gradmax_normalization'
         gradmax_scale : float
             For ``gradmax_normalization`` only: scalar :math:`s` in :math:`c = s \\cdot \\text{mean}(\\|W_i\\|)`.
@@ -2871,6 +2886,7 @@ class GrowingModule(torch.nn.Module):
         existing_normalizations = [
             "equalize_second_layer",
             "equalize_extensions",
+            "match_extending_layer",
             "weird_normalization",
             "legacy_normalization",
             "gradmax_normalization",
@@ -2951,18 +2967,18 @@ class GrowingModule(torch.nn.Module):
                     scales[non_zero_mask] = target_norm / extension_norms[non_zero_mask]
                     extension_weight.mul_(scales.view(*reshape_shape))
                     if self.eigenvalues_extension is not None:
-                        ev = self.eigenvalues_extension
-                        ev.mul_(
+                        self.eigenvalues_extension.mul_(
                             torch.sqrt(
                                 scales.to(
-                                    device=ev.device,
-                                    dtype=ev.dtype,
+                                    device=self.eigenvalues_extension.device,
+                                    dtype=self.eigenvalues_extension.dtype,
                                 )
                             )
                         )
             return
 
-        # Determine target standard deviation
+        # Determine target standard deviation (not used by match_extending_layer,
+        # which computes per-target stds below).
         if std_target is None:
             if (
                 hasattr(self.layer, "weight")
@@ -2981,67 +2997,102 @@ class GrowingModule(torch.nn.Module):
                 std_target = 1.0 / (
                     self.get_fan_in_from_layer(self.extended_input_layer) ** 0.5
                 )
-        assert isinstance(std_target, float), "std_target must be a float."
-        assert std_target > 0, "std_target must be positive."
+        assert isinstance(std_target, float) and std_target > 0, (
+            "std_target must be a positive float."
+        )
 
-        def _get_scale(layer: torch.nn.Module | None, target_std: float) -> float:
+        def _std_of_layer(layer: torch.nn.Module | None) -> float | None:
             """
-            Calculate the scaling factor for a layer to reach the target standard
-            deviation.
+            Return the std of ``layer.weight``, or a kaiming-like fallback.
 
-            If the layer is None or has no weights, return 1.0.
-            If the current standard deviation is 0, return
-            self.get_fan_in_from_layer(layer) ** (-0.5).
+            Returns ``None`` when ``layer`` is missing or has no weights;
+            returns ``layer.weight.std().item()`` when positive; otherwise
+            returns ``get_fan_in_from_layer(layer) ** -0.5``.
 
             Parameters
             ----------
-            layer: torch.nn.Module | None
-                The layer to calculate the scaling factor for.
-            target_std: float
-                The target standard deviation.
+            layer : torch.nn.Module | None
+                Layer whose ``.weight`` std we want.
+
+            Returns
+            -------
+            float | None
+                The std, the fallback, or ``None`` when no weights exist.
+            """
+            if (
+                layer is None
+                or not hasattr(layer, "weight")
+                or layer.weight is None
+                or layer.weight.numel() == 0
+            ):
+                return None
+            else:
+                std = layer.weight.std().item()
+                if std > 0:
+                    return std
+                else:
+                    return self.get_fan_in_from_layer(layer) ** (-0.5)
+
+        def _scale_to(layer: torch.nn.Module | None, target_std: float) -> float:
+            """
+            Scaling factor that brings ``layer``'s std to ``target_std``.
+
+            Returns 1.0 when ``layer`` has no weights to scale.
+
+            Parameters
+            ----------
+            layer : torch.nn.Module | None
+                Layer being scaled.
+            target_std : float
+                Desired std after scaling.
 
             Returns
             -------
             float
-                The scaling factor for the layer.
+                Multiplicative factor to apply to ``layer.weight``.
             """
-            if layer is not None and hasattr(layer, "weight"):
-                if (current_std := layer.weight.std().item()) > 0:
-                    return target_std / current_std
-                else:
-                    return self.get_fan_in_from_layer(layer) ** (-0.5)
-            else:
-                return 1.0
+            current_std = _std_of_layer(layer)
+            return 1.0 if current_std is None else target_std / current_std
 
         if normalization_type == "equalize_second_layer":
-            # Get current standard deviations and calculate scaling factors
-            delta_scale = _get_scale(self.optimal_delta_layer, std_target)
-            input_extension_scale = _get_scale(self.extended_input_layer, std_target)
-            # Calculate output extension scale to maintain relationship
+            delta_scale = _scale_to(self.optimal_delta_layer, std_target)
+            input_extension_scale = _scale_to(self.extended_input_layer, std_target)
             output_extension_scale = delta_scale / input_extension_scale
-        elif normalization_type == "equalize_extensions":
-            # Get current standard deviations and calculate scaling factors
-            input_extension_scale = _get_scale(self.extended_input_layer, std_target)
-
-            if self.previous_module is not None:
-                assert isinstance(self.previous_module, GrowingModule)
-                output_extension_scale = _get_scale(
-                    self.previous_module.extended_output_layer,
-                    std_target,
+        elif normalization_type == "match_extending_layer":
+            if self.previous_module is None or not hasattr(self.previous_module, "layer"):
+                raise ValueError(
+                    "match_extending_layer requires a previous GrowingModule "
+                    "with a .layer attribute."
                 )
-            else:
+            # Target std for each component = std of the layer it modifies.
+            # When the target layer has no weights (e.g. an identity/empty
+            # layer), fall back to a kaiming-like std computed from the
+            # extension's fan-in.
+            prev_ext = self.previous_module.extended_output_layer
+            self_std = _std_of_layer(self.layer)
+            if self_std is None and self.extended_input_layer is not None:
+                self_std = self.get_fan_in_from_layer(self.extended_input_layer) ** -0.5
+            prev_std = _std_of_layer(self.previous_module.layer)
+            if prev_std is None and prev_ext is not None:
+                prev_std = self.get_fan_in_from_layer(prev_ext) ** -0.5
+            input_extension_scale = _scale_to(self.extended_input_layer, self_std)
+            output_extension_scale = _scale_to(prev_ext, prev_std)
+            delta_scale = _scale_to(self.optimal_delta_layer, self_std)
+        elif normalization_type == "equalize_extensions":
+            if self.previous_module is None:
                 raise ValueError(
                     "Cannot use equalize_extensions normalization "
                     "as there is no previous module."
                 )
-            # Calculate delta scale to maintain relationship
+            assert isinstance(self.previous_module, GrowingModule)
+            input_extension_scale = _scale_to(self.extended_input_layer, std_target)
+            output_extension_scale = _scale_to(
+                self.previous_module.extended_output_layer, std_target
+            )
             delta_scale = input_extension_scale * output_extension_scale
-        elif (
-            normalization_type == "legacy_normalization"
-            or normalization_type == "weird_normalization"
-        ):
-            delta_scale = _get_scale(self.optimal_delta_layer, std_target)
-            output_extension_scale = _get_scale(self.extended_input_layer, std_target)
+        elif normalization_type in ("legacy_normalization", "weird_normalization"):
+            delta_scale = _scale_to(self.optimal_delta_layer, std_target)
+            output_extension_scale = _scale_to(self.extended_input_layer, std_target)
             input_extension_scale = 1.0
         else:
             raise ValueError(

--- a/tests/test_growing_block.py
+++ b/tests/test_growing_block.py
@@ -1661,6 +1661,60 @@ class TestLinearGrowingBlock(TorchTestCase):
             msg="Second layer extension weights std should match original weights std",
         )
 
+    def test_normalize_optimal_updates_match_extending_layer(self):
+        """
+        Test ``normalize_optimal_updates`` with ``match_extending_layer``.
+
+        Each update component should match the std of the layer it modifies:
+        - ``second_layer.extended_input_layer`` (Omega) -> std(second_layer.weight)
+        - ``first_layer.extended_output_layer``  (Alpha) -> std(first_layer.weight)
+        - ``second_layer.optimal_delta_layer``   (dW)    -> std(second_layer.weight)
+        """
+        block = LinearGrowingBlock(
+            in_features=self.in_features,
+            out_features=self.in_features,
+            hidden_features=self.hidden_features,
+            device=self.device,
+        )
+        block.first_layer.weight.data *= 2.0
+        block.second_layer.weight.data *= 0.1
+
+        block.create_layer_extensions(self.added_features)
+        assert isinstance(block.first_layer.extended_output_layer, torch.nn.Linear)
+        assert isinstance(block.second_layer.extended_input_layer, torch.nn.Linear)
+
+        block.second_layer.optimal_delta_layer = torch.nn.Linear(
+            block.second_layer.in_features,
+            block.second_layer.out_features,
+            bias=block.second_layer.use_bias,
+            device=self.device,
+        )
+
+        first_std = block.first_layer.weight.std().item()
+        second_std = block.second_layer.weight.std().item()
+
+        block.normalize_optimal_updates(normalization_type="match_extending_layer")
+
+        self.assertAlmostEqual(
+            block.second_layer.extended_input_layer.weight.std().item(),
+            second_std,
+            places=2,
+            msg="Omega should match std(second_layer.weight)",
+        )
+        self.assertAlmostEqual(
+            block.first_layer.extended_output_layer.weight.std().item(),
+            first_std,
+            places=2,
+            msg="Alpha should match std(first_layer.weight)",
+        )
+        assert isinstance(block.second_layer.optimal_delta_layer, torch.nn.Linear)
+        self.assertAlmostEqual(
+            block.second_layer.optimal_delta_layer.weight.std().item(),
+            second_std,
+            places=2,
+            msg="dW should match std(second_layer.weight)",
+        )
+
     def test_weights_statistics(self):
         """Test that weights_statistics method runs and returns a dictionary."""
 

--- a/tests/test_growing_block.py
+++ b/tests/test_growing_block.py
@@ -1715,6 +1715,53 @@ class TestLinearGrowingBlock(TorchTestCase):
             msg="dW should match std(second_layer.weight)",
         )
 
+    def test_normalize_optimal_updates_match_extending_layer_empty_layers(self):
+        """
+        Test ``match_extending_layer`` fallback when inner layers have no weights.
+
+        A block with ``hidden_features=0`` has empty weights in both inner
+        layers, so the target std for each component must come from the
+        kaiming-like fallback ``get_fan_in_from_layer(extension) ** -0.5``.
+        """
+        block = LinearGrowingBlock(
+            in_features=self.in_features,
+            out_features=self.in_features,
+            hidden_features=0,
+            device=self.device,
+        )
+
+        block.create_layer_extensions(self.added_features)
+        assert isinstance(block.first_layer.extended_output_layer, torch.nn.Linear)
+        assert isinstance(block.second_layer.extended_input_layer, torch.nn.Linear)
+
+        block.normalize_optimal_updates(normalization_type="match_extending_layer")
+
+        expected_second_std = (
+            block.second_layer.get_fan_in_from_layer(
+                block.second_layer.extended_input_layer
+            )
+            ** -0.5
+        )
+        expected_first_std = (
+            block.first_layer.get_fan_in_from_layer(
+                block.first_layer.extended_output_layer
+            )
+            ** -0.5
+        )
+
+        self.assertAlmostEqual(
+            block.second_layer.extended_input_layer.weight.std().item(),
+            expected_second_std,
+            places=5,
+            msg="Omega should match kaiming fallback of second_layer's fan-in",
+        )
+        self.assertAlmostEqual(
+            block.first_layer.extended_output_layer.weight.std().item(),
+            expected_first_std,
+            places=5,
+            msg="Alpha should match kaiming fallback of first_layer's fan-in",
+        )
+
     def test_weights_statistics(self):
         """Test that weights_statistics method runs and returns a dictionary."""
 

--- a/tests/test_linear_growing_module.py
+++ b/tests/test_linear_growing_module.py
@@ -3952,6 +3952,94 @@ class TestScalingMethods(TestLinearGrowingModuleBase):
                     msg="No scaling should be applied when target norm is zero.",
                 )
 
+        with self.subTest(case="match_extending_layer"):
+            # match_extending_layer:
+            # Omega <- std(W_out)/std(Omega) * Omega => std(Omega_new) = std(W_out)
+            # Alpha <- std(W_in)/std(Alpha) * Alpha  => std(Alpha_new) = std(W_in)
+            # dW    <- std(W_out)/std(dW) * dW       => std(dW_new)    = std(W_out)
+            std_weights, std_delta, std_alpha, std_omega = 2.0, 3.0, 5.0, 7.0
+            layer_out = setup_layers_with_known_stds(
+                std_weights, std_delta, std_alpha, std_omega
+            )
+            assert isinstance(layer_out.previous_module, LinearGrowingModule)
+            std_weights_in = layer_out.previous_module.layer.weight.std().item()
+
+            layer_out.normalize_optimal_updates(
+                std_target=None, normalization_type="match_extending_layer"
+            )
+
+            assert isinstance(layer_out.extended_input_layer, torch.nn.Linear)
+            self.assertAlmostEqual(
+                layer_out.extended_input_layer.weight.std().item(),
+                std_weights,
+                places=5,
+                msg="Omega should be scaled to std(W_out)",
+            )
+            assert isinstance(
+                layer_out.previous_module.extended_output_layer, torch.nn.Linear
+            )
+            self.assertAlmostEqual(
+                layer_out.previous_module.extended_output_layer.weight.std().item(),
+                std_weights_in,
+                places=5,
+                msg="Alpha should be scaled to std(W_in)",
+            )
+            assert isinstance(layer_out.optimal_delta_layer, torch.nn.Linear)
+            self.assertAlmostEqual(
+                layer_out.optimal_delta_layer.weight.std().item(),
+                std_weights,
+                places=5,
+                msg="dW should be scaled to std(W_out)",
+            )
+
+        with self.subTest(case="match_extending_layer_no_previous_module"):
+            layer_out = set_up_network_for_normalization_test()
+            layer_out.previous_module = None
+            with self.assertRaises(ValueError):
+                layer_out.normalize_optimal_updates(
+                    std_target=None, normalization_type="match_extending_layer"
+                )
+
+        with self.subTest(case="match_extending_layer_missing_components"):
+            # None components must be skipped without error.
+            layer_out = setup_layers_with_known_stds(2.0, 3.0, 5.0, 7.0)
+            assert isinstance(layer_out.previous_module, LinearGrowingModule)
+            prev = layer_out.previous_module
+
+            layer_out.optimal_delta_layer = None
+            layer_out.extended_input_layer = None
+
+            assert isinstance(prev.extended_output_layer, torch.nn.Linear)
+            alpha_std_before = prev.extended_output_layer.weight.std().item()
+
+            # Should not raise even though two of the three components are None.
+            layer_out.normalize_optimal_updates(
+                std_target=None, normalization_type="match_extending_layer"
+            )
+
+            # Alpha is applied via scale_layer_extension which requires
+            # extended_input_layer to be set; here it stays untouched.
+            self.assertAlmostEqual(
+                prev.extended_output_layer.weight.std().item(),
+                alpha_std_before,
+                places=5,
+            )
+
+        with self.subTest(case="match_extending_layer_zero_std_previous_layer"):
+            # A previous layer whose weights have std == 0 (or no weights) should
+            # fall back to the kaiming-like std via the extension's fan-in instead
+            # of raising.
+            layer_out = setup_layers_with_known_stds(2.0, 3.0, 5.0, 7.0)
+            assert isinstance(layer_out.previous_module, LinearGrowingModule)
+            # Zero out the previous layer's weights to force the fallback path.
+            layer_out.previous_module.layer.weight.data.zero_()
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                layer_out.normalize_optimal_updates(
+                    std_target=None, normalization_type="match_extending_layer"
+                )
+
 
 class TestCreateLayerExtensions(TestLinearGrowingModuleBase):
     """Test create_layer_extensions method for LinearGrowingModule."""


### PR DESCRIPTION
Introduce a new normalization that match the extension std to the std of weights that are already in the layer.