### PR TITLE
enh: Add the use of empirical Fisher conditioning for delta weights and new parameters

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -20,13 +20,13 @@ Develop branch
 Enhancements
 ~~~~~~~~~~~~
 
-
+- Add an empirical Fisher (loss-gradient covariance) as an optional preconditioner for both optimal-delta weight updates and rank-k neuron extension computations (:gh:`250` by `Théo Rudkiewicz`_).
 - Add GradMax normalization details and associated tests for update scaling behavior (:gh:`242` by `Pako Maxence TEKOU`_)
 - Introduce an empirical Fisher / loss-gradient covariance statistic to GrowingModule-based layers (:gh:`249` by `Théo Rudkiewicz`_).
 - Introduce decoupled scaling factors for GrowingModule behavior, separating scaling for the optimal-delta update, the input extension, and the output extension (:gh:`245` by `Théo Rudkiewicz`_).
 - Introduce VGG-like growing architecture support with the `VGG` class (:gh:`236` by `Hugo Mousset`_)
-- Adds support for selecting GroupNorm as the normalization layer in the ResNet container, alongside the existing BatchNorm option (:gh:`233` by `Théo Rudkiewicz`_).
-- Adds configurability to the ResNet container to allow using BatchNorm2d or disabling normalization entirely (:gh:`228` by `Théo Rudkiewicz`_)
+- Add support for selecting GroupNorm as the normalization layer in the ResNet container, alongside the existing BatchNorm option (:gh:`233` by `Théo Rudkiewicz`_).
+- Add configurability to the ResNet container to allow using BatchNorm2d or disabling normalization entirely (:gh:`228` by `Théo Rudkiewicz`_)
 - Add ``uv`` files, use ``uv sync --extra dev --extra test --extra doc`` to install the package with all dependencies (:gh:`226` by `Théo Rudkiewicz`_)
 - Use ``ruff`` for formatting (:gh:`227` by `Théo Rudkiewicz`_)
 - Change how size-dependent post_layer_function modules handle extended activities in the growing module framework (:gh:`224` by `Théo Rudkiewicz`_)

--- a/src/gromo/containers/growing_block.py
+++ b/src/gromo/containers/growing_block.py
@@ -405,6 +405,7 @@ class GrowingBlock(GrowingContainer):
         omega_zero: bool = False,
         use_projection: bool = True,
         ignore_singular_values: bool = False,
+        use_fisher: bool = False,
     ) -> None:
         """
         Compute the optimal update for second layer and additional neurons.
@@ -441,6 +442,9 @@ class GrowingBlock(GrowingContainer):
         ignore_singular_values: bool
             If True, ignore singular values and treat them as 1, only using singular
             vectors for the update direction. Default is False.
+        use_fisher: bool
+            If True, use the empirical Fisher / gradient covariance as
+            preconditioner on the output side. Default is False.
 
         Note
         ----
@@ -485,6 +489,7 @@ class GrowingBlock(GrowingContainer):
                 omega_zero=omega_zero,
                 use_projection=False,  # Must be False when hidden_neurons == 0
                 ignore_singular_values=ignore_singular_values,
+                use_fisher=use_fisher,
             )
         else:
             # When hidden_neurons > 0, delegate to second layer's
@@ -502,6 +507,7 @@ class GrowingBlock(GrowingContainer):
                 omega_zero=omega_zero,
                 use_projection=use_projection,
                 ignore_singular_values=ignore_singular_values,
+                use_fisher=use_fisher,
             )
 
     def apply_change(

--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -1700,6 +1700,7 @@ class RestrictedConv2dGrowingModule(Conv2dGrowingModule):
         omega_zero: bool = False,
         use_projection: bool = True,
         ignore_singular_values: bool = False,
+        use_fisher: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
         """
         Compute the optimal added parameters to extend the input layer.
@@ -1730,6 +1731,9 @@ class RestrictedConv2dGrowingModule(Conv2dGrowingModule):
         ignore_singular_values: bool
             if True, ignore singular values and treat them as 1, only using singular
             vectors for the update direction
+        use_fisher: bool
+            if True, use the empirical Fisher / gradient covariance as
+            preconditioner on the output side.
 
         Returns
         -------
@@ -1752,6 +1756,7 @@ class RestrictedConv2dGrowingModule(Conv2dGrowingModule):
             omega_zero=omega_zero,
             use_projection=use_projection,
             ignore_singular_values=ignore_singular_values,
+            use_fisher=use_fisher,
         )
 
         k = self.eigenvalues_extension.shape[0]
@@ -2140,6 +2145,7 @@ class FullConv2dGrowingModule(Conv2dGrowingModule):
         omega_zero: bool = False,
         use_projection: bool = True,
         ignore_singular_values: bool = False,
+        use_fisher: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
         """
         Compute the optimal added parameters to extend the input layer.
@@ -2170,6 +2176,11 @@ class FullConv2dGrowingModule(Conv2dGrowingModule):
         ignore_singular_values: bool
             if True, ignore singular values and treat them as 1, only using singular
             vectors for the update direction
+        use_fisher: bool
+            if True, use the empirical Fisher / gradient covariance as
+            preconditioner. Not supported for FullConv2dGrowingModule because
+            the SVD output dimension is `out_channels * k_h * k_w`, not
+            `out_channels`.
 
         Returns
         -------
@@ -2180,8 +2191,17 @@ class FullConv2dGrowingModule(Conv2dGrowingModule):
         Raises
         ------
         NotImplementedError
-            if the previous module is not of type Conv2dGrowingModule
+            if the previous module is not of type Conv2dGrowingModule, or if
+            ``use_fisher`` is True (not implemented for the Full variant).
         """
+        if use_fisher:
+            raise NotImplementedError(
+                "use_fisher=True is not supported for FullConv2dGrowingModule "
+                "because the output dimension of the SVD target is "
+                "out_channels * k_h * k_w, which does not match the "
+                "(out_channels, out_channels) shape of "
+                "covariance_loss_gradient."
+            )
         alpha, omega, self.eigenvalues_extension = self._auxiliary_compute_alpha_omega(
             numerical_threshold=numerical_threshold,
             statistical_threshold=statistical_threshold,

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -2182,11 +2182,17 @@ class GrowingModule(torch.nn.Module):
         update: bool = True,
         dtype: torch.dtype = torch.float32,
         force_pseudo_inverse: bool = False,
+        use_fisher: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | float]:
         """
         Compute the optimal delta for the layer using current S and M tensors.
 
-        dW* = M S[-1]^-1 (if needed we use the pseudo-inverse)
+        With ``tensor_m`` shaped ``(in_features(+bias), out_features)``, the raw
+        optimal update returned by ``optimal_delta`` corresponds to
+        ``(S^-1 M)^T``, using the pseudo-inverse of ``S`` when needed.
+        When ``use_fisher`` is True, the empirical Fisher / gradient covariance
+        ``E_s = E[dA dA^T]`` is used as an output-feature left preconditioner, so
+        the update is correspondingly preconditioned on the output side.
 
         Compute dW* (and dBias* if needed) and update the optimal_delta_layer attribute.
         L(A + gamma * B * dW) = L(A) - gamma * d + o(gamma)
@@ -2201,6 +2207,10 @@ class GrowingModule(torch.nn.Module):
         force_pseudo_inverse: bool
             if True, use the pseudo-inverse to compute the optimal delta even if the
             matrix is invertible
+        use_fisher: bool
+            if True, use the empirical Fisher / gradient covariance as a left
+            preconditioner. Relies on the independence hypothesis from the math
+            notes (`@hyp:independence`).
 
         Returns
         -------
@@ -2210,9 +2220,16 @@ class GrowingModule(torch.nn.Module):
         """
         tensor_s = self.tensor_s()
         tensor_m = self.tensor_m()
+        tensor_covariance_loss_gradient = (
+            self.covariance_loss_gradient() if use_fisher else None
+        )
 
         self.delta_raw, parameter_update_decrease = optimal_delta(
-            tensor_s, tensor_m, dtype=dtype, force_pseudo_inverse=force_pseudo_inverse
+            tensor_s,
+            tensor_m,
+            dtype=dtype,
+            force_pseudo_inverse=force_pseudo_inverse,
+            tensor_covariance_loss_gradient=tensor_covariance_loss_gradient,
         )
 
         if self.use_bias:
@@ -2240,6 +2257,7 @@ class GrowingModule(torch.nn.Module):
         omega_zero: bool = False,
         use_projection: bool = True,
         ignore_singular_values: bool = False,
+        use_fisher: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         """
         Auxiliary function to compute the optimal added parameters (alpha, omega, k)
@@ -2268,6 +2286,9 @@ class GrowingModule(torch.nn.Module):
         ignore_singular_values: bool
             if True, ignore singular values and treat them as 1, only using singular
             vectors for the update direction
+        use_fisher: bool
+            if True, use the covariance of the loss gradient as an additional
+            preconditioner when computing the neuron extension
 
         Returns
         -------
@@ -2288,11 +2309,16 @@ class GrowingModule(torch.nn.Module):
         # Determine matrix_s based on use_covariance
         matrix_s = self.tensor_s_growth() if use_covariance else None
 
+        # Determine matrix_e based on use_fisher (current layer's gradient covariance)
+        matrix_e = self.covariance_loss_gradient() if use_fisher else None
+
         saved_dtype = matrix_n.dtype
         if matrix_n.dtype != dtype:
             matrix_n = matrix_n.to(dtype=dtype)
         if matrix_s is not None and matrix_s.dtype != dtype:
             matrix_s = matrix_s.to(dtype=dtype)
+        if matrix_e is not None and matrix_e.dtype != dtype:
+            matrix_e = matrix_e.to(dtype=dtype)
 
         # Call tools function with primitive options
         alpha, omega, eigenvalues_extension = compute_optimal_added_parameters(
@@ -2304,6 +2330,7 @@ class GrowingModule(torch.nn.Module):
             alpha_zero=alpha_zero,
             omega_zero=omega_zero,
             ignore_singular_values=ignore_singular_values,
+            matrix_covariance_loss_gradient=matrix_e,
         )
 
         alpha = alpha.to(dtype=saved_dtype)
@@ -2324,6 +2351,7 @@ class GrowingModule(torch.nn.Module):
         omega_zero: bool = False,
         use_projection: bool = True,
         ignore_singular_values: bool = False,
+        use_fisher: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
         """
         Compute the optimal added parameters to extend the input layer.
@@ -2355,6 +2383,9 @@ class GrowingModule(torch.nn.Module):
         ignore_singular_values: bool
             if True, ignore singular values and treat them as 1, only using singular
             vectors for the update direction
+        use_fisher: bool
+            if True, use the covariance of the loss gradient as an additional
+            preconditioner when computing the neuron extension
 
         Returns
         -------
@@ -2403,6 +2434,7 @@ class GrowingModule(torch.nn.Module):
         omega_zero: bool = False,
         use_projection: bool = True,
         ignore_singular_values: bool = False,
+        use_fisher: bool = False,
     ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
         """
         Compute the optimal update and additional neurons.
@@ -2460,6 +2492,9 @@ class GrowingModule(torch.nn.Module):
         ignore_singular_values: bool
             Whether to ignore singular values and treat them as 1. When True, only the
             singular vectors are used for the update direction.
+        use_fisher: bool
+            Whether to use the covariance of the loss gradient as an additional
+            preconditioner for delta and neuron-extension computations.
 
         Returns
         -------
@@ -2479,7 +2514,7 @@ class GrowingModule(torch.nn.Module):
         # - compute_delta=False/use_projection=False: no natural-gradient step,
         #   so set the corresponding first-order term to zero.
         if compute_delta:
-            self.compute_optimal_delta(update=True, dtype=dtype)
+            self.compute_optimal_delta(update=True, dtype=dtype, use_fisher=use_fisher)
         else:
             self.optimal_delta_layer = None
             self.parameter_update_decrease = torch.tensor(
@@ -2488,7 +2523,9 @@ class GrowingModule(torch.nn.Module):
                 dtype=self.weight.dtype,
             )
             if use_projection and self.previous_module is not None:
-                self.compute_optimal_delta(update=False, dtype=dtype)
+                self.compute_optimal_delta(
+                    update=False, dtype=dtype, use_fisher=use_fisher
+                )
             else:
                 self.delta_raw = None
                 self.parameter_update_decrease = torch.tensor(
@@ -2511,6 +2548,7 @@ class GrowingModule(torch.nn.Module):
                 omega_zero=omega_zero,
                 use_projection=use_projection,
                 ignore_singular_values=ignore_singular_values,
+                use_fisher=use_fisher,
             )
             return alpha_weight, alpha_bias
         elif isinstance(self.previous_module, MergeGrowingModule):

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -2184,14 +2184,14 @@ class GrowingModule(torch.nn.Module):
         force_pseudo_inverse: bool = False,
         use_fisher: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | float]:
-        """
+        r"""
         Compute the optimal delta for the layer using current S and M tensors.
 
         With ``tensor_m`` shaped ``(in_features(+bias), out_features)``, the raw
         optimal update returned by ``optimal_delta`` corresponds to
-        ``(S^-1 M)^T``, using the pseudo-inverse of ``S`` when needed.
+        :math:`(S^-1 M)^T`, using the pseudo-inverse of ``S`` when needed.
         When ``use_fisher`` is True, the empirical Fisher / gradient covariance
-        ``E_s = E[dA dA^T]`` is used as an output-feature left preconditioner, so
+        :math:`E_s = \mathbb{E}[dA dA^T]` is used as an output-feature left preconditioner, so
         the update is correspondingly preconditioned on the output side.
 
         Compute dW* (and dBias* if needed) and update the optimal_delta_layer attribute.

--- a/src/gromo/modules/linear_growing_module.py
+++ b/src/gromo/modules/linear_growing_module.py
@@ -937,6 +937,7 @@ class LinearGrowingModule(GrowingModule):
         omega_zero: bool = False,
         use_projection: bool = True,
         ignore_singular_values: bool = False,
+        use_fisher: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor, torch.Tensor]:
         """
         Compute the optimal added parameters to extend the input layer.
@@ -966,6 +967,9 @@ class LinearGrowingModule(GrowingModule):
         ignore_singular_values: bool
             if True, ignore singular values and treat them as 1, only using singular
             vectors for the update direction
+        use_fisher: bool
+            if True, use the covariance of the loss gradient as an additional
+            preconditioner when computing the neuron extension
 
         Returns
         -------
@@ -993,6 +997,7 @@ class LinearGrowingModule(GrowingModule):
             omega_zero=omega_zero,
             use_projection=use_projection,
             ignore_singular_values=ignore_singular_values,
+            use_fisher=use_fisher,
         )
         k = self.eigenvalues_extension.shape[0]
         assert alpha.shape[0] == omega.shape[1], (

--- a/src/gromo/utils/tools.py
+++ b/src/gromo/utils/tools.py
@@ -55,11 +55,15 @@ def optimal_delta(
     tensor_m: torch.Tensor,
     dtype: torch.dtype = torch.float32,
     force_pseudo_inverse: bool = False,
+    tensor_covariance_loss_gradient: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """
     Compute the optimal delta for the layer using current S and M tensors.
 
-    dW* = S[-1]^-1 M (if needed we use the pseudo-inverse)
+    dW* = (S[-1]^-1 M)^T (if needed we use the pseudo-inverse). When the empirical
+    Fisher / gradient covariance E_s is provided via
+    ``tensor_covariance_loss_gradient``, the natural-gradient-like preconditioned
+    update is used instead: dW* = (S^-1 M E_s^-1)^T = E_s^-1 M^T S^-1.
 
     Compute dW* (and dBias* if needed).
     L(A + gamma * B * dW) = L(A) - gamma * d + o(gamma)
@@ -76,6 +80,11 @@ def optimal_delta(
     force_pseudo_inverse: bool, optional
         if True, use the pseudo-inverse to compute the optimal delta even if the
         matrix is invertible, by default False
+    tensor_covariance_loss_gradient: torch.Tensor | None, optional
+        empirical Fisher E_s of shape (out_features, out_features). When provided
+        the preconditioned update dW* = E_s^-1 M^T S^-1 is returned. Note that
+        relying on this preconditioner silently uses the independence hypothesis
+        described in `first_order_optimization.typ` (`@hyp:independence`).
 
     Returns
     -------
@@ -93,6 +102,11 @@ def optimal_delta(
         tensor_s = tensor_s.to(dtype=dtype)
     if tensor_m.dtype != dtype:
         tensor_m = tensor_m.to(dtype=dtype)
+    if (
+        tensor_covariance_loss_gradient is not None
+        and tensor_covariance_loss_gradient.dtype != dtype
+    ):
+        tensor_covariance_loss_gradient = tensor_covariance_loss_gradient.to(dtype=dtype)
 
     delta_raw = None
     if not force_pseudo_inverse:
@@ -107,6 +121,20 @@ def optimal_delta(
         delta_raw = (torch.linalg.pinv(tensor_s) @ tensor_m).t()
 
     assert delta_raw is not None, "delta_raw should be computed by now."
+
+    if tensor_covariance_loss_gradient is not None:
+        applied_pinv = force_pseudo_inverse
+        if not applied_pinv:
+            try:
+                delta_raw = torch.linalg.solve(tensor_covariance_loss_gradient, delta_raw)
+            except torch.linalg.LinAlgError:
+                applied_pinv = True
+                warn(
+                    "Using the pseudo-inverse for the gradient covariance preconditioner."
+                )
+        if applied_pinv:
+            delta_raw = torch.linalg.pinv(tensor_covariance_loss_gradient) @ delta_raw
+
     assert delta_raw.isnan().sum() == 0, (
         "The optimal delta should not contain NaN values."
     )
@@ -119,7 +147,11 @@ def optimal_delta(
         if not force_pseudo_inverse:
             warn("Trying to use the pseudo-inverse with torch.float64.")
             return optimal_delta(
-                tensor_s, tensor_m, dtype=torch.float64, force_pseudo_inverse=True
+                tensor_s,
+                tensor_m,
+                dtype=torch.float64,
+                force_pseudo_inverse=True,
+                tensor_covariance_loss_gradient=tensor_covariance_loss_gradient,
             )
         else:
             warn("Failed to compute the optimal delta, set delta to zero.")
@@ -141,6 +173,7 @@ def compute_optimal_added_parameters(
     alpha_zero: bool = False,
     omega_zero: bool = False,
     ignore_singular_values: bool = False,
+    matrix_covariance_loss_gradient: torch.Tensor | None = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Compute the optimal added parameters for a given layer.
@@ -166,6 +199,12 @@ def compute_optimal_added_parameters(
     ignore_singular_values : bool
         If True, ignore the actual singular values and treat them as 1 for computing alpha and
         omega, effectively only using the singular vectors for the update direction.
+    matrix_covariance_loss_gradient : torch.Tensor | None
+        Square matrix E_s of shape (t, t). If provided, the SVD target becomes
+        S^{-1/2} N E_s^{-1/2} and omega is left-multiplied by E_s^{-1/2}, which
+        applies the empirical-Fisher preconditioning to the rank-k extension.
+        Note that this silently uses the independence hypothesis described in
+        `first_order_optimization.typ` (`@hyp:independence`).
 
     Returns
     -------
@@ -182,7 +221,7 @@ def compute_optimal_added_parameters(
         If SVD of S^{-1/2} N fails.
     """
     # Validate inputs
-    n_1, _ = matrix_n.shape
+    n_1, n_2 = matrix_n.shape
 
     if matrix_s is not None:
         # validate S matrix
@@ -214,6 +253,26 @@ def compute_optimal_added_parameters(
         matrix_s_inverse_sqrt = torch.eye(
             n_1, device=matrix_n.device, dtype=matrix_n.dtype
         )
+
+    # Optional empirical-Fisher preconditioner on the output side.
+    matrix_e_inverse_sqrt: torch.Tensor | None = None
+    if matrix_covariance_loss_gradient is not None:
+        e_1, e_2 = matrix_covariance_loss_gradient.shape
+        assert e_1 == e_2, "The input matrix E must be square."
+        assert e_2 == n_2, (
+            f"The input matrices E and N must have compatible shapes."
+            f"(got {matrix_covariance_loss_gradient.shape=} and {matrix_n.shape=})"
+        )
+        if not torch.allclose(
+            matrix_covariance_loss_gradient, matrix_covariance_loss_gradient.t()
+        ):
+            matrix_covariance_loss_gradient = (
+                matrix_covariance_loss_gradient + matrix_covariance_loss_gradient.t()
+            ) / 2
+        matrix_e_inverse_sqrt = sqrt_inverse_matrix_semi_positive(
+            matrix_covariance_loss_gradient, threshold=numerical_threshold
+        )
+        matrix_p = matrix_p @ matrix_e_inverse_sqrt
 
     # Compute the SVD of the product
     try:
@@ -247,6 +306,10 @@ def compute_optimal_added_parameters(
         sqrt_s = torch.sqrt(torch.abs(s))
     alpha = sqrt_s * (matrix_s_inverse_sqrt @ u)
     omega = sqrt_s[:, None] * v
+    if matrix_e_inverse_sqrt is not None:
+        # omega has shape (k, t); apply E^{-1/2} on the right so the eventual
+        # transposed result (t, k) is left-multiplied by E^{-1/2}.
+        omega = omega @ matrix_e_inverse_sqrt
 
     if alpha_zero:
         alpha = torch.zeros_like(alpha)

--- a/src/gromo/utils/tools.py
+++ b/src/gromo/utils/tools.py
@@ -60,10 +60,10 @@ def optimal_delta(
     """
     Compute the optimal delta for the layer using current S and M tensors.
 
-    dW* = (S[-1]^-1 M)^T (if needed we use the pseudo-inverse). When the empirical
+    :math:`dW^* = (S[-1]^-1 M)^T` (if needed we use the pseudo-inverse). When the empirical
     Fisher / gradient covariance E_s is provided via
     ``tensor_covariance_loss_gradient``, the natural-gradient-like preconditioned
-    update is used instead: dW* = (S^-1 M E_s^-1)^T = E_s^-1 M^T S^-1.
+    update is used instead: :math:`dW^* = (S^-1 M E_s^-1)^T = E_s^-1 M^T S^-1`.
 
     Compute dW* (and dBias* if needed).
     L(A + gamma * B * dW) = L(A) - gamma * d + o(gamma)

--- a/tests/test_conv2d_growing_module.py
+++ b/tests/test_conv2d_growing_module.py
@@ -928,6 +928,24 @@ class TestConv2dGrowingModule(TestConv2dGrowingModuleBase):
         cov = self.demo.covariance_loss_gradient()
         self.assertShapeEqual(cov, (self.demo.out_channels, self.demo.out_channels))
 
+    def test_compute_optimal_delta_use_fisher(self):
+        """Smoke test: Conv2d compute_optimal_delta runs with use_fisher=True."""
+        self.demo.init_computation()
+        y = self.demo(self.input_x)
+        torch.norm(y).backward()
+        self.demo.update_computation()
+
+        self.demo.compute_optimal_delta(use_fisher=True)
+        self.assertShapeEqual(
+            self.demo.delta_raw,
+            (
+                self.demo.out_channels,
+                self.demo.in_channels
+                * self.demo.kernel_size[0]
+                * self.demo.kernel_size[1],
+            ),
+        )
+
     @unittest_parametrize(({"bias": True}, {"bias": False}))
     def test_compute_optimal_delta(self, bias: bool = False):
         if bias:

--- a/tests/test_linear_growing_module.py
+++ b/tests/test_linear_growing_module.py
@@ -1222,6 +1222,7 @@ class TestLinearGrowingModule(TestLinearGrowingModuleBase):
             "eigenvalues_extension",
             "tensor_m_prev",
             "cross_covariance",
+            "covariance_loss_gradient",
         ]
 
         # Set up test network using helper method
@@ -1289,6 +1290,7 @@ class TestLinearGrowingModule(TestLinearGrowingModuleBase):
             use_projection=True,
             use_covariance=True,
             alpha_zero=False,
+            use_fisher=True,
         )
 
         self.assertShapeEqual(
@@ -1505,6 +1507,117 @@ class TestLinearGrowingModule(TestLinearGrowingModuleBase):
 
         cov = layer.covariance_loss_gradient()
         self.assertShapeEqual(cov, (out_features, out_features))
+
+    def test_compute_optimal_delta_use_fisher(self):
+        """Smoke test: compute_optimal_delta runs with use_fisher=True."""
+        in_features, out_features, batch = 3, 4, 6
+        layer = LinearGrowingModule(in_features, out_features, device=global_device())
+        layer.init_computation()
+
+        x = torch.randn(batch, in_features, device=global_device())
+        layer(x).pow(2).sum().backward()
+        layer.update_computation()
+
+        w, _, fo = layer.compute_optimal_delta(use_fisher=True, update=False)
+        self.assertShapeEqual(w, (out_features, in_features))
+        self.assertGreaterEqual(float(fo), 0.0)
+
+    def test_compute_optimal_added_parameters_use_fisher(self):
+        """Smoke test: rank-k extension runs with use_fisher=True."""
+        in_features, hidden, out_features, batch = 4, 3, 5, 8
+        layer1 = LinearGrowingModule(
+            in_features, hidden, device=global_device(), name="l1"
+        )
+        layer2 = LinearGrowingModule(
+            hidden,
+            out_features,
+            device=global_device(),
+            previous_module=layer1,
+            name="l2",
+        )
+        net = torch.nn.Sequential(layer1, layer2)
+
+        layer1.init_computation()
+        layer2.init_computation()
+
+        x = torch.randn(batch, in_features, device=global_device())
+        net(x).pow(2).sum().backward()
+        layer1.update_computation()
+        layer2.update_computation()
+
+        alpha_w, _alpha_b = layer2.compute_optimal_updates(use_fisher=True)
+        self.assertEqual(alpha_w.shape[1], in_features)
+        self.assertEqual(layer2.eigenvalues_extension.ndim, 1)
+
+    def test_compute_optimal_delta_use_fisher_closed_form(self):
+        r"""
+        Closed-form delta-test: rank-1 Fisher rescales the optimal delta by 1/||W||^2.
+
+        We use a single LinearGrowingModule of shape 1 -> 2, no bias, identity
+        post-activation, with weight ``W_0 = [[1], [1]]``. Inputs are the
+        balanced batch ``x = [+1, -1]`` so that the empirical second moment
+        ``hat_E[x^2] = 1``.  The loss is ``sum_i 1/2 * ||y_i||^2``; the
+        library normalises sums by `samples` on read.
+
+        Per-sample:
+            h_i = x_i in R,    nabla_s ell_i = W_0 * x_i in R^2.
+
+        Aggregated statistics (with hat_E[x^2] = 1):
+            tensor_s          (= bar_C_h)         = 1
+            tensor_m          (= G^T)             = W_0^T = [[1, 1]]
+            covariance_loss_gradient (= bar_E_s)  = W_0 W_0^T = [[1, 1], [1, 1]]
+                                                  (rank-1, exercises the pinv path)
+
+        Closed-form predictions for delta_raw (shape (cp, cm) = (2, 1)):
+            delta_no_fisher = G * bar_C_h^{-1}                 = W_0       = [[1], [1]]
+            delta_fisher    = bar_E_s^+ * G * bar_C_h^{-1}     = W_0 / ||W_0||^2 = [[0.5], [0.5]]
+        """
+        device = global_device()
+        layer = LinearGrowingModule(
+            1, 2, use_bias=False, device=device, name="closed_form_delta"
+        )
+        layer.layer.weight.data = torch.tensor([[1.0], [1.0]], device=device)
+        W0 = layer.layer.weight.data.clone()
+
+        layer.init_computation()
+        x = torch.tensor([[1.0], [-1.0]], device=device)
+        # Sanity-check: hat E[x^2] = 1 so that bar_C_h = 1.
+        assert torch.isclose((x.flatten() ** 2).mean(), torch.tensor(1.0, device=device))
+
+        y = layer(x)
+        loss = 0.5 * (y**2).sum()
+        loss.backward()
+        layer.update_computation()
+
+        # The recorded statistics must match the closed-form values described
+        # in the docstring; otherwise the rest of the test is meaningless.
+        self.assertAllClose(
+            layer.tensor_s(),
+            torch.tensor([[1.0]], device=device),
+        )
+        self.assertAllClose(layer.tensor_m(), W0.t())
+        self.assertAllClose(
+            layer.covariance_loss_gradient(),
+            W0 @ W0.t(),
+        )
+        # Independent check that bar_E_s is rank 1 (eigvals ~ {||W_0||^2, 0}).
+        eigvals = torch.linalg.eigvalsh(layer.covariance_loss_gradient())
+        assert float(eigvals[0]) < 1e-6 and abs(float(eigvals[1]) - 2.0) < 1e-6, (
+            f"Expected eigvals ~ (0, ||W_0||^2 = 2), got {eigvals.tolist()}"
+        )
+
+        # No-Fisher baseline: delta_raw = W_0.
+        delta_no_f, _, fo_no_f = layer.compute_optimal_delta(
+            use_fisher=False, update=False
+        )
+        self.assertAllClose(delta_no_f, W0)
+        self.assertGreater(float(fo_no_f), 0.0)
+
+        # Fisher: delta_raw = W_0 / ||W_0||^2.
+        delta_f, _, fo_f = layer.compute_optimal_delta(use_fisher=True, update=False)
+        norm_sq = float(W0.pow(2).sum())  # = 2
+        self.assertAllClose(delta_f, W0 / norm_sq)
+        self.assertGreater(float(fo_f), 0.0)
 
     def test_negative_parameter_update_decrease_paths(self):
         """Test that the layer emits the expected warning when parameter_update_decrease is negative.

--- a/tests/test_natural_gradient_invariance.py
+++ b/tests/test_natural_gradient_invariance.py
@@ -1,0 +1,583 @@
+r"""Natural-gradient invariance tests for the empirical-Fisher integration.
+
+Setup
+-----
+We work with a 4-layer purely linear network (no biases, identity post-
+activations):
+
+    x ---W_1---> h_1 ---W_2---> h_2 ---W_3---> h_3 ---W_4---> y
+
+The network admits a well-known scaling symmetry: if we multiply ``W_1`` by a
+positive scalar ``c`` and divide ``W_4`` by ``c`` (so that the leading factor
+introduced at the input is undone at the output), the network function ``y(x)``
+is exactly preserved. Note that the natural symmetry is ``W_4 <- W_4 / c``
+rather than ``W_4 <- c * W_4``: the latter would change the output by a
+factor of ``c**2``.
+
+Under that rescaling, we focus on layer L3 (the third hidden layer, with
+previous_module = L2). Direct computation gives the per-sample scalings:
+
+    h_2 (= L3.input)            ~ c       (because L1's output is scaled by c
+                                          and W_2 is unchanged, so h_2 ~ c)
+    pre_3                       ~ c
+    dA_3 = d(loss)/d(pre_3)     ~ 1/c    (chain rule: scaling pre_3 by c
+                                          divides its gradient by c)
+
+so the recorded statistics scale as
+
+    tensor_s_growth (= L2.tensor_s)              ~ c**2
+    tensor_m_prev   (= L3.tensor_m_prev)         ~ 1     (= c * 1/c)
+    tensor_s        (= L3.tensor_s)              ~ c**2
+    tensor_m        (= L3.tensor_m)              ~ 1
+    covariance_loss_gradient (L3.cov_grad)       ~ 1/c**2.
+
+From these, the predictions verified below are:
+
+* ``compute_optimal_delta``::
+
+      use_fisher=False:  delta_raw = (S^{-1} M)^T               ~ 1/c**2
+      use_fisher=True:   delta_raw = E^{-1} (S^{-1} M)^T         ~ 1   (invariant)
+
+* ``compute_optimal_added_parameters`` singular values
+  (``eigenvalues_extension``, with ``compute_delta=False`` and
+  ``use_projection=False`` so the SVD operates on ``-tensor_m_prev``)::
+
+      use_covariance=False, use_fisher=False:
+          P = N                                 ~ 1               (invariant)
+      use_covariance=True,  use_fisher=False:
+          P = S^{-1/2} N                        ~ 1/c             (scales by 1/c)
+      use_covariance=True,  use_fisher=True:
+          P = S^{-1/2} N E^{+/2}                ~ 1               (invariant)
+"""
+
+import torch
+
+from gromo.modules.conv2d_growing_module import RestrictedConv2dGrowingModule
+from gromo.modules.linear_growing_module import LinearGrowingModule
+from gromo.utils.utils import global_device
+from tests.torch_unittest import TorchTestCase
+
+
+class TestNaturalGradientInvariance(TorchTestCase):
+    SEED = 42
+    BATCH_SIZE = 16
+    # in -> L1_out -> L2_out -> L3_out -> L4_out
+    DIMS = (3, 4, 5, 4, 2)
+    # Non-trivial scaling factor; kept moderate to avoid driving any
+    # eigenvalue below the numerical / statistical thresholds used inside
+    # ``compute_optimal_added_parameters``.
+    SCALE = 2.0
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _build_net(self, c: float):
+        """Build the 4-layer linear chain with the rescaling W_1 *= c,
+        W_4 /= c applied to the (otherwise deterministic) weights.
+
+        L1 and L4 are plain `nn.Linear` and are frozen -- we only collect
+        statistics on L3 (with previous_module = L2). The same input batch
+        and target are reused across calls.
+        """
+        device = global_device()
+        d0, d1, d2, d3, d4 = self.DIMS
+
+        torch.manual_seed(self.SEED)
+        l1 = torch.nn.Linear(d0, d1, bias=False, device=device)
+        l2 = LinearGrowingModule(d1, d2, use_bias=False, device=device, name="l2")
+        l3 = LinearGrowingModule(
+            d2, d3, use_bias=False, previous_module=l2, device=device, name="l3"
+        )
+        l4 = torch.nn.Linear(d3, d4, bias=False, device=device)
+
+        with torch.no_grad():
+            l1.weight.mul_(c)
+            l4.weight.mul_(1.0 / c)
+
+        for p in l1.parameters():
+            p.requires_grad_(False)
+        for p in l4.parameters():
+            p.requires_grad_(False)
+
+        torch.manual_seed(self.SEED + 1)
+        x = torch.randn(self.BATCH_SIZE, d0, device=device)
+        target = torch.randn(self.BATCH_SIZE, d4, device=device)
+
+        return l1, l2, l3, l4, x, target
+
+    def _collect_stats(self, l1, l2, l3, l4, x, target):
+        """Run a single forward+backward and update L3's statistics."""
+        l3.init_computation()
+        net = torch.nn.Sequential(l1, l2, l3, l4)
+        y = net(x)
+        loss = 0.5 * ((y - target) ** 2).sum()
+        loss.backward()
+        l3.update_computation()
+
+    # ------------------------------------------------------------------
+    # Sanity check
+    # ------------------------------------------------------------------
+
+    def test_network_output_is_c_invariant(self):
+        """Sanity: the rescaling W_1 *= c, W_4 /= c preserves ``y(x)``.
+
+        This is a precondition for the rest of the file: if the rescaled
+        network produced a different output, the gradients would also differ
+        and the predicted scalings of the statistics would not hold.
+        """
+        l1_a, l2_a, l3_a, l4_a, x_a, _ = self._build_net(c=1.0)
+        y_a = torch.nn.Sequential(l1_a, l2_a, l3_a, l4_a)(x_a).detach()
+
+        l1_b, l2_b, l3_b, l4_b, x_b, _ = self._build_net(c=self.SCALE)
+        y_b = torch.nn.Sequential(l1_b, l2_b, l3_b, l4_b)(x_b).detach()
+
+        # Same input must give the same output.
+        assert torch.allclose(x_a, x_b)
+        self.assertAllClose(y_a, y_b, atol=1e-5, rtol=1e-5)
+
+    # ------------------------------------------------------------------
+    # Predicted statistics scalings (also a useful debugging aid)
+    # ------------------------------------------------------------------
+
+    def test_recorded_statistics_scale_as_predicted(self):
+        """Verify the per-statistic scalings used in the analytical predictions
+        of the two main tests below.
+        """
+        c = self.SCALE
+
+        l1, l2, l3, l4, x, target = self._build_net(c=1.0)
+        self._collect_stats(l1, l2, l3, l4, x, target)
+        s_growth_ref = l3.tensor_s_growth().detach().clone()
+        m_prev_ref = l3.tensor_m_prev().detach().clone()
+        s_ref = l3.tensor_s().detach().clone()
+        m_ref = l3.tensor_m().detach().clone()
+        cov_ref = l3.covariance_loss_gradient().detach().clone()
+
+        l1, l2, l3, l4, x, target = self._build_net(c=c)
+        self._collect_stats(l1, l2, l3, l4, x, target)
+        # tensor_s_growth ~ c**2
+        self.assertAllClose(l3.tensor_s_growth(), (c * c) * s_growth_ref, atol=1e-5)
+        # tensor_m_prev ~ 1 (invariant)
+        self.assertAllClose(l3.tensor_m_prev(), m_prev_ref, atol=1e-5)
+        # tensor_s ~ c**2
+        self.assertAllClose(l3.tensor_s(), (c * c) * s_ref, atol=1e-5)
+        # tensor_m ~ 1
+        self.assertAllClose(l3.tensor_m(), m_ref, atol=1e-5)
+        # covariance_loss_gradient ~ 1/c**2
+        self.assertAllClose(
+            l3.covariance_loss_gradient(),
+            cov_ref / (c * c),
+            atol=1e-5,
+            rtol=1e-4,
+        )
+
+    # ------------------------------------------------------------------
+    # Test 1: optimal_delta natural-gradient invariance
+    # ------------------------------------------------------------------
+
+    def test_optimal_delta_natural_gradient_invariance(self):
+        r"""Without Fisher, ``delta_raw`` scales by ``1/c**2``; with Fisher
+        it is invariant under the natural-gradient reparameterization
+        ``W_1 -> c * W_1, W_4 -> W_4 / c``.
+        """
+        c = self.SCALE
+
+        # --- reference run (c = 1) ---
+        l1, l2, l3, l4, x, target = self._build_net(c=1.0)
+        self._collect_stats(l1, l2, l3, l4, x, target)
+        delta_no_f_ref, _, _ = l3.compute_optimal_delta(use_fisher=False, update=False)
+        delta_f_ref, _, _ = l3.compute_optimal_delta(use_fisher=True, update=False)
+        delta_no_f_ref = delta_no_f_ref.detach().clone()
+        delta_f_ref = delta_f_ref.detach().clone()
+        # Sanity: the reference solutions should be non-trivially non-zero
+        # (otherwise the rescaling test below is vacuous).
+        assert delta_no_f_ref.norm().item() > 1e-3
+        assert delta_f_ref.norm().item() > 1e-3
+
+        # --- rescaled run (c = SCALE) ---
+        l1, l2, l3, l4, x, target = self._build_net(c=c)
+        self._collect_stats(l1, l2, l3, l4, x, target)
+        delta_no_f_resc, _, _ = l3.compute_optimal_delta(use_fisher=False, update=False)
+        delta_f_resc, _, _ = l3.compute_optimal_delta(use_fisher=True, update=False)
+
+        # Without Fisher: delta_resc ~ delta_ref / c**2.
+        self.assertAllClose(
+            delta_no_f_resc,
+            delta_no_f_ref / (c * c),
+            atol=1e-5,
+            rtol=1e-4,
+            msg="Without Fisher, delta_raw should scale by 1/c**2 under the "
+            "natural-gradient reparameterization.",
+        )
+        # And the rescaled delta must clearly differ from the reference (i.e.
+        # the rescaling actually had an effect).
+        self.assertGreater(
+            (delta_no_f_resc - delta_no_f_ref).abs().max().item(),
+            1e-3,
+            "Without Fisher, delta_raw should change under the rescaling; "
+            "if it does not, either the rescaling is not effective or the "
+            "reference delta is too small to make the test meaningful.",
+        )
+
+        # With Fisher: delta_raw is invariant.
+        self.assertAllClose(
+            delta_f_resc,
+            delta_f_ref,
+            atol=1e-5,
+            rtol=1e-4,
+            msg="With Fisher (use_fisher=True), delta_raw must be invariant "
+            "under the natural-gradient reparameterization.",
+        )
+
+    # ------------------------------------------------------------------
+    # Test 2: eigenvalues_extension natural-gradient invariance
+    # ------------------------------------------------------------------
+
+    def test_eigenvalues_extension_natural_gradient_invariance(self):
+        r"""For ``compute_optimal_updates(compute_delta=False)`` on L3, the
+        singular values returned in ``eigenvalues_extension`` scale as:
+
+        * use_covariance=False, use_fisher=False  ->  invariant
+        * use_covariance=True,  use_fisher=False  ->  scales by 1/c
+        * use_covariance=True,  use_fisher=True   ->  invariant
+        """
+        c = self.SCALE
+
+        def run(c_val: float, *, use_covariance: bool, use_fisher: bool):
+            l1, l2, l3, l4, x, target = self._build_net(c=c_val)
+            self._collect_stats(l1, l2, l3, l4, x, target)
+            l3.compute_optimal_updates(
+                compute_delta=False,
+                use_covariance=use_covariance,
+                use_fisher=use_fisher,
+                use_projection=False,
+            )
+            return l3.eigenvalues_extension.detach().clone()
+
+        # Singular values come back sorted in non-increasing order from
+        # `torch.linalg.svd`; we sort defensively in case of ties.
+        def sort_desc(t: torch.Tensor) -> torch.Tensor:
+            return t.sort(descending=True).values
+
+        # --- 1) no covariance, no Fisher: P = N ~ 1, sigmas invariant. ---
+        eig_ref_1 = run(1.0, use_covariance=False, use_fisher=False)
+        eig_resc_1 = run(c, use_covariance=False, use_fisher=False)
+        self.assertEqual(eig_ref_1.shape, eig_resc_1.shape)
+        # Sanity: ref must be non-trivial.
+        assert eig_ref_1.max().item() > 1e-3
+        self.assertAllClose(
+            sort_desc(eig_resc_1),
+            sort_desc(eig_ref_1),
+            atol=1e-5,
+            rtol=1e-4,
+            msg="use_covariance=False, use_fisher=False: eigenvalues should "
+            "be c-invariant.",
+        )
+
+        # --- 2) covariance only: P = S^{-1/2} N ~ 1/c, sigmas scale by 1/c. ---
+        eig_ref_2 = run(1.0, use_covariance=True, use_fisher=False)
+        eig_resc_2 = run(c, use_covariance=True, use_fisher=False)
+        self.assertEqual(eig_ref_2.shape, eig_resc_2.shape)
+        assert eig_ref_2.max().item() > 1e-3
+        self.assertAllClose(
+            sort_desc(eig_resc_2),
+            sort_desc(eig_ref_2) / c,
+            atol=1e-5,
+            rtol=1e-4,
+            msg="use_covariance=True, use_fisher=False: eigenvalues should scale by 1/c.",
+        )
+        self.assertGreater(
+            (sort_desc(eig_resc_2) - sort_desc(eig_ref_2)).abs().max().item(),
+            1e-3,
+            "use_covariance=True, use_fisher=False: eigenvalues must change "
+            "under the rescaling.",
+        )
+
+        # --- 3) covariance + Fisher: P = S^{-1/2} N E^{+/2} ~ 1, invariant. ---
+        eig_ref_3 = run(1.0, use_covariance=True, use_fisher=True)
+        eig_resc_3 = run(c, use_covariance=True, use_fisher=True)
+        self.assertEqual(eig_ref_3.shape, eig_resc_3.shape)
+        assert eig_ref_3.max().item() > 1e-3
+        self.assertAllClose(
+            sort_desc(eig_resc_3),
+            sort_desc(eig_ref_3),
+            atol=1e-5,
+            rtol=1e-4,
+            msg="use_covariance=True, use_fisher=True: eigenvalues should "
+            "be c-invariant.",
+        )
+
+
+class TestNaturalGradientInvarianceRestrictedConv2d(TorchTestCase):
+    r"""Same scale-invariance check as ``TestNaturalGradientInvariance`` but for
+    a chain of ``RestrictedConv2dGrowingModule``\ s.
+
+    Layout: ``conv2d_a -> RestrictedConv2dGrowingModule_b
+                       -> RestrictedConv2dGrowingModule_c
+                       -> conv2d_d``.
+
+    All convolutions are 3x3 with padding=1 and stride=1 so that the spatial
+    dimension is preserved end-to-end. Like in the linear case, the network is
+    purely linear (identity post-activations everywhere, no biases) so the
+    rescaling ``W_a *= c, W_d /= c`` exactly preserves the network output.
+
+    Conv2d statistics scale identically to the linear case because all
+    convolutions are linear in the input, so the unfolded inputs pick up the
+    same factor as the input activations:
+
+        L_b.input  ~ c       L_c.input  ~ c       pre_c ~ c       dA_c ~ 1/c
+        tensor_s_growth (= L_b.tensor_s)         ~ c**2
+        tensor_m_prev   (= L_c.tensor_m_prev)    ~ 1
+        tensor_s        (= L_c.tensor_s)         ~ c**2
+        tensor_m        (= L_c.tensor_m)         ~ 1
+        covariance_loss_gradient (L_c)           ~ 1/c**2.
+
+    The predicted scalings of ``compute_optimal_delta`` and
+    ``eigenvalues_extension`` are therefore identical to the linear case.
+    """
+
+    SEED = 42
+    BATCH_SIZE = 4
+    SPATIAL = (5, 5)
+    # in -> L_a_out -> L_b_out -> L_c_out -> L_d_out
+    CHANNELS = (2, 4, 5, 4, 2)
+    SCALE = 2.0
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _build_net(self, c: float):
+        r"""Build the 4-conv chain with the rescaling W_a *= c, W_d /= c.
+
+        L_a and L_d are plain ``torch.nn.Conv2d`` (frozen). L_b and L_c are
+        ``RestrictedConv2dGrowingModule``\ s, with ``L_c.previous_module = L_b``
+        so that we collect statistics on L_c (with L_b providing
+        ``tensor_s_growth``).
+        """
+        device = global_device()
+        c0, c1, c2, c3, c4 = self.CHANNELS
+
+        torch.manual_seed(self.SEED)
+        l_a = torch.nn.Conv2d(
+            c0, c1, kernel_size=3, padding=1, stride=1, bias=False, device=device
+        )
+        l_b = RestrictedConv2dGrowingModule(
+            in_channels=c1,
+            out_channels=c2,
+            kernel_size=3,
+            padding=1,
+            stride=1,
+            use_bias=False,
+            device=device,
+            name="l_b",
+        )
+        l_c = RestrictedConv2dGrowingModule(
+            in_channels=c2,
+            out_channels=c3,
+            kernel_size=3,
+            padding=1,
+            stride=1,
+            use_bias=False,
+            previous_module=l_b,
+            device=device,
+            name="l_c",
+        )
+        l_d = torch.nn.Conv2d(
+            c3, c4, kernel_size=3, padding=1, stride=1, bias=False, device=device
+        )
+
+        with torch.no_grad():
+            l_a.weight.mul_(c)
+            l_d.weight.mul_(1.0 / c)
+
+        for p in l_a.parameters():
+            p.requires_grad_(False)
+        for p in l_d.parameters():
+            p.requires_grad_(False)
+
+        torch.manual_seed(self.SEED + 1)
+        h, w = self.SPATIAL
+        x = torch.randn(self.BATCH_SIZE, c0, h, w, device=device)
+        target = torch.randn(self.BATCH_SIZE, c4, h, w, device=device)
+
+        return l_a, l_b, l_c, l_d, x, target
+
+    def _collect_stats(self, l_a, l_b, l_c, l_d, x, target):
+        """Single forward+backward pass that populates L_c's statistics."""
+        l_c.init_computation()
+        net = torch.nn.Sequential(l_a, l_b, l_c, l_d)
+        y = net(x)
+        loss = 0.5 * ((y - target) ** 2).sum()
+        loss.backward()
+        l_c.update_computation()
+
+    # ------------------------------------------------------------------
+    # Sanity check
+    # ------------------------------------------------------------------
+
+    def test_network_output_is_c_invariant(self):
+        """Sanity: the rescaling W_a *= c, W_d /= c preserves ``y(x)``."""
+        l_a_1, l_b_1, l_c_1, l_d_1, x_1, _ = self._build_net(c=1.0)
+        y_1 = torch.nn.Sequential(l_a_1, l_b_1, l_c_1, l_d_1)(x_1).detach()
+
+        l_a_2, l_b_2, l_c_2, l_d_2, x_2, _ = self._build_net(c=self.SCALE)
+        y_2 = torch.nn.Sequential(l_a_2, l_b_2, l_c_2, l_d_2)(x_2).detach()
+
+        assert torch.allclose(x_1, x_2)
+        self.assertAllClose(y_1, y_2, atol=1e-5, rtol=1e-5)
+
+    # ------------------------------------------------------------------
+    # Predicted statistics scalings
+    # ------------------------------------------------------------------
+
+    def test_recorded_statistics_scale_as_predicted(self):
+        c = self.SCALE
+
+        l_a, l_b, l_c, l_d, x, target = self._build_net(c=1.0)
+        self._collect_stats(l_a, l_b, l_c, l_d, x, target)
+        s_growth_ref = l_c.tensor_s_growth().detach().clone()
+        m_prev_ref = l_c.tensor_m_prev().detach().clone()
+        s_ref = l_c.tensor_s().detach().clone()
+        m_ref = l_c.tensor_m().detach().clone()
+        cov_ref = l_c.covariance_loss_gradient().detach().clone()
+
+        l_a, l_b, l_c, l_d, x, target = self._build_net(c=c)
+        self._collect_stats(l_a, l_b, l_c, l_d, x, target)
+        self.assertAllClose(
+            l_c.tensor_s_growth(), (c * c) * s_growth_ref, atol=1e-5, rtol=1e-4
+        )
+        self.assertAllClose(l_c.tensor_m_prev(), m_prev_ref, atol=1e-5, rtol=1e-4)
+        self.assertAllClose(l_c.tensor_s(), (c * c) * s_ref, atol=1e-5, rtol=1e-4)
+        self.assertAllClose(l_c.tensor_m(), m_ref, atol=1e-5, rtol=1e-4)
+        self.assertAllClose(
+            l_c.covariance_loss_gradient(),
+            cov_ref / (c * c),
+            atol=1e-5,
+            rtol=1e-4,
+        )
+
+    # ------------------------------------------------------------------
+    # Test 1: optimal_delta natural-gradient invariance
+    # ------------------------------------------------------------------
+
+    def test_optimal_delta_natural_gradient_invariance(self):
+        r"""Without Fisher, ``delta_raw`` scales by ``1/c**2``; with Fisher
+        it is invariant under the natural-gradient reparameterization
+        ``W_a *= c, W_d /= c``.
+        """
+        c = self.SCALE
+
+        l_a, l_b, l_c, l_d, x, target = self._build_net(c=1.0)
+        self._collect_stats(l_a, l_b, l_c, l_d, x, target)
+        delta_no_f_ref, _, _ = l_c.compute_optimal_delta(use_fisher=False, update=False)
+        delta_f_ref, _, _ = l_c.compute_optimal_delta(use_fisher=True, update=False)
+        delta_no_f_ref = delta_no_f_ref.detach().clone()
+        delta_f_ref = delta_f_ref.detach().clone()
+        assert delta_no_f_ref.norm().item() > 1e-3
+        assert delta_f_ref.norm().item() > 1e-3
+
+        l_a, l_b, l_c, l_d, x, target = self._build_net(c=c)
+        self._collect_stats(l_a, l_b, l_c, l_d, x, target)
+        delta_no_f_resc, _, _ = l_c.compute_optimal_delta(use_fisher=False, update=False)
+        delta_f_resc, _, _ = l_c.compute_optimal_delta(use_fisher=True, update=False)
+
+        # Without Fisher: delta_raw scales by 1/c**2.
+        self.assertAllClose(
+            delta_no_f_resc,
+            delta_no_f_ref / (c * c),
+            atol=1e-5,
+            rtol=1e-4,
+            msg="Conv2d / no-Fisher: delta_raw should scale by 1/c**2.",
+        )
+        self.assertGreater(
+            (delta_no_f_resc - delta_no_f_ref).abs().max().item(),
+            1e-3,
+            "Conv2d / no-Fisher: delta_raw must change under the rescaling.",
+        )
+
+        # With Fisher: delta_raw is invariant.
+        self.assertAllClose(
+            delta_f_resc,
+            delta_f_ref,
+            atol=1e-5,
+            rtol=1e-4,
+            msg="Conv2d / Fisher: delta_raw must be invariant.",
+        )
+
+    # ------------------------------------------------------------------
+    # Test 2: eigenvalues_extension natural-gradient invariance
+    # ------------------------------------------------------------------
+
+    def test_eigenvalues_extension_natural_gradient_invariance(self):
+        r"""For ``compute_optimal_updates(compute_delta=False)`` on L_c, the
+        singular values returned in ``eigenvalues_extension`` scale as:
+
+        * use_covariance=False, use_fisher=False  ->  invariant
+        * use_covariance=True,  use_fisher=False  ->  scales by 1/c
+        * use_covariance=True,  use_fisher=True   ->  invariant
+        """
+        c = self.SCALE
+
+        def run(c_val: float, *, use_covariance: bool, use_fisher: bool):
+            l_a, l_b, l_c, l_d, x, target = self._build_net(c=c_val)
+            self._collect_stats(l_a, l_b, l_c, l_d, x, target)
+            l_c.compute_optimal_updates(
+                compute_delta=False,
+                use_covariance=use_covariance,
+                use_fisher=use_fisher,
+                use_projection=False,
+            )
+            return l_c.eigenvalues_extension.detach().clone()
+
+        def sort_desc(t: torch.Tensor) -> torch.Tensor:
+            return t.sort(descending=True).values
+
+        # 1) no covariance, no Fisher: P = N ~ 1, sigmas invariant.
+        eig_ref_1 = run(1.0, use_covariance=False, use_fisher=False)
+        eig_resc_1 = run(c, use_covariance=False, use_fisher=False)
+        self.assertEqual(eig_ref_1.shape, eig_resc_1.shape)
+        assert eig_ref_1.max().item() > 1e-3
+        self.assertAllClose(
+            sort_desc(eig_resc_1),
+            sort_desc(eig_ref_1),
+            atol=1e-5,
+            rtol=1e-4,
+            msg="Conv2d / use_covariance=False, use_fisher=False: eigenvalues "
+            "should be c-invariant.",
+        )
+
+        # 2) covariance only: P = S^{-1/2} N ~ 1/c, sigmas scale by 1/c.
+        eig_ref_2 = run(1.0, use_covariance=True, use_fisher=False)
+        eig_resc_2 = run(c, use_covariance=True, use_fisher=False)
+        self.assertEqual(eig_ref_2.shape, eig_resc_2.shape)
+        assert eig_ref_2.max().item() > 1e-3
+        self.assertAllClose(
+            sort_desc(eig_resc_2),
+            sort_desc(eig_ref_2) / c,
+            atol=1e-5,
+            rtol=1e-4,
+            msg="Conv2d / use_covariance=True, use_fisher=False: eigenvalues "
+            "should scale by 1/c.",
+        )
+        self.assertGreater(
+            (sort_desc(eig_resc_2) - sort_desc(eig_ref_2)).abs().max().item(),
+            1e-3,
+            "Conv2d / use_covariance=True, use_fisher=False: eigenvalues must "
+            "change under the rescaling.",
+        )
+
+        # 3) covariance + Fisher: P = S^{-1/2} N E^{+/2} ~ 1, invariant.
+        eig_ref_3 = run(1.0, use_covariance=True, use_fisher=True)
+        eig_resc_3 = run(c, use_covariance=True, use_fisher=True)
+        self.assertEqual(eig_ref_3.shape, eig_resc_3.shape)
+        assert eig_ref_3.max().item() > 1e-3
+        self.assertAllClose(
+            sort_desc(eig_resc_3),
+            sort_desc(eig_ref_3),
+            atol=1e-5,
+            rtol=1e-4,
+            msg="Conv2d / use_covariance=True, use_fisher=True: eigenvalues "
+            "should be c-invariant.",
+        )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -540,11 +540,15 @@ class TestTools(TorchTestCase):
         """Test basic functionality of compute_optimal_delta with normal and forced pseudo-inverse."""
         # Create test matrices
         tensor_s = torch.eye(3) * 2.0
+        gradient_covariance = torch.eye(2) * 0.5
         tensor_m = torch.randn(3, 2)
 
         # Test computation with either normal or forced pseudo-inverse
         delta, decrease = optimal_delta(
-            tensor_s, tensor_m, force_pseudo_inverse=force_pseudo_inverse
+            tensor_s,
+            tensor_m,
+            force_pseudo_inverse=force_pseudo_inverse,
+            tensor_covariance_loss_gradient=gradient_covariance,
         )
 
         # Verify output shapes
@@ -561,10 +565,16 @@ class TestTools(TorchTestCase):
         """Test dtype conversion in compute_optimal_delta."""
         # Create test matrices with same dtype
         tensor_s = torch.eye(3, dtype=torch.float64) * 2.0
+        gradient_covariance = torch.eye(2, dtype=torch.float64) * 0.5
         tensor_m = torch.randn(3, 2, dtype=torch.float64)
 
         # Test with specified dtype conversion
-        delta, decrease = optimal_delta(tensor_s, tensor_m, dtype=torch.float32)
+        delta, decrease = optimal_delta(
+            tensor_s,
+            tensor_m,
+            dtype=torch.float32,
+            tensor_covariance_loss_gradient=gradient_covariance,
+        )
 
         # Should preserve original dtype in output
         self.assertEqual(delta.dtype, torch.float64)  # Original tensor dtype


### PR DESCRIPTION
Add an empirical Fisher (loss-gradient covariance)  as an optional preconditioner for both optimal-delta weight updates and rank‑k neuron extension computations.