### PR TITLE
Maxence/mlp like sequential container

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -20,6 +20,7 @@ Develop branch
 Enhancements
 ~~~~~~~~~~~~
 
+- Refactored growing MLP containers to use `SequentialGrowingContainer` for a more unified model manipulation interface (:gh:`253` by `Pako Maxence TEKOU`_)
 - Add an empirical Fisher (loss-gradient covariance) as an optional preconditioner for both optimal-delta weight updates and rank-k neuron extension computations (:gh:`250` by `Théo Rudkiewicz`_).
 - Add GradMax normalization details and associated tests for update scaling behavior (:gh:`242` by `Pako Maxence TEKOU`_)
 - Introduce an empirical Fisher / loss-gradient covariance statistic to GrowingModule-based layers (:gh:`249` by `Théo Rudkiewicz`_).

--- a/examples/plot_growing_container_tutorial.py
+++ b/examples/plot_growing_container_tutorial.py
@@ -342,7 +342,7 @@ for step in range(growth_steps):
         history["num_params"].append(count_parameters(model))
         history["step_type"].append("SGD")
 
-    layer_to_grow: int = step % max(1, number_hidden_layers) + 1
+    layer_to_grow: int = step % max(1, number_hidden_layers)
     print(f"Growing layer {layer_to_grow}")
     grow(model, device, train_data_loader, layer_to_grow=layer_to_grow)
     print("Model after growing:")

--- a/examples/plot_growing_container_tutorial.py
+++ b/examples/plot_growing_container_tutorial.py
@@ -181,7 +181,8 @@ def grow(
     train_loader : torch.utils.data.DataLoader
         DataLoader providing batches of (input, target) pairs.
     layer_to_grow : int
-        Index of the layer to grow (1-indexed).
+        Index of the layer to grow (1-indexed over growable layers,
+        i.e. excludes the input layer and follows the ordering of _growable_layers).
 
     Notes
     -----
@@ -196,7 +197,7 @@ def grow(
     criterion_sum = torch.nn.MSELoss(reduction="sum")
     criterion_mean = torch.nn.MSELoss(reduction="mean")
 
-    model.set_growing_layers(layer_to_grow)
+    model.set_growing_layers(index=layer_to_grow)
     compute_statistics(
         model,
         train_loader,

--- a/src/gromo/containers/growing_mlp.py
+++ b/src/gromo/containers/growing_mlp.py
@@ -146,6 +146,23 @@ class GrowingMLP(SequentialGrowingModel):
             x, x_ext = layer.extended_forward(x, x_ext)
         return x
 
+    def update_information(self) -> dict[str, Any]:
+        """Update information for all growing layers including first order improvement
+        Returns
+        -------
+        dict[str, Any]
+            information dictionary
+        """
+        information = {}
+        for i, layer in enumerate(self._growing_layers):
+            layer_information = {
+                "update_value": layer.first_order_improvement,
+                "parameter_improvement": layer.parameter_update_decrease,
+                "eigenvalues_extension": layer.eigenvalues_extension,
+            }
+            information[i] = layer_information
+        return information
+
     def normalise(self, verbose: bool = False) -> None:
         """Normalize the weight of the model
 

--- a/src/gromo/containers/growing_mlp.py
+++ b/src/gromo/containers/growing_mlp.py
@@ -148,6 +148,7 @@ class GrowingMLP(SequentialGrowingModel):
 
     def update_information(self) -> dict[str, Any]:
         """Update information for all growing layers including first order improvement
+
         Returns
         -------
         dict[str, Any]

--- a/src/gromo/containers/growing_mlp.py
+++ b/src/gromo/containers/growing_mlp.py
@@ -3,11 +3,11 @@ from typing import Any
 import torch
 from torch import Tensor, nn
 
-from gromo.containers.growing_container import GrowingModel
+from gromo.containers.sequential_growing_container import SequentialGrowingModel
 from gromo.modules.linear_growing_module import LinearGrowingModule
 
 
-class GrowingMLP(GrowingModel):
+class GrowingMLP(SequentialGrowingModel):
     """
     Represents a growing MLP network.
 
@@ -98,14 +98,8 @@ class GrowingMLP(GrowingModel):
             )
         )
 
-        self.set_growing_layers()
-
-    def set_growing_layers(self, index: int | None = None) -> None:
-        """Reference all growable layers of the model in the _growing_layers private attribute"""
-        if index is not None:
-            self._growing_layers = [self.layers[index]]  # type: ignore
-        else:
-            self._growing_layers = list(self.layers[1:])  # type: ignore
+        self._growable_layers = list(self.layers[1:])
+        self.set_growing_layers(scheduling_method="all")
 
     def forward(self, x: Tensor) -> Tensor:
         """
@@ -151,24 +145,6 @@ class GrowingMLP(GrowingModel):
         for layer in self.layers:
             x, x_ext = layer.extended_forward(x, x_ext)
         return x
-
-    def update_information(self) -> dict[str, Any]:
-        """Update information for all growing layers including first order improvement
-
-        Returns
-        -------
-        dict[str, Any]
-            information dictionary
-        """
-        information = {}
-        for i, layer in enumerate(self._growing_layers):
-            layer_information = {
-                "update_value": layer.first_order_improvement,
-                "parameter_improvement": layer.parameter_update_decrease,
-                "eigenvalues_extension": layer.eigenvalues_extension,
-            }
-            information[i] = layer_information
-        return information
 
     def normalise(self, verbose: bool = False) -> None:
         """Normalize the weight of the model

--- a/src/gromo/containers/growing_mlp_mixer.py
+++ b/src/gromo/containers/growing_mlp_mixer.py
@@ -5,6 +5,7 @@ import torch.nn as nn
 from torch import Tensor
 
 from gromo.containers.growing_container import GrowingContainer
+from gromo.containers.sequential_growing_container import SequentialGrowingModel
 from gromo.modules.linear_growing_module import LinearGrowingModule
 from gromo.utils.utils import compute_tensor_stats
 
@@ -500,7 +501,7 @@ def check_sizes(image_size: int, patch_size: int) -> int:
     return num_patches
 
 
-class GrowingMLPMixer(GrowingContainer):
+class GrowingMLPMixer(SequentialGrowingModel):
     """
     Represents a growing MLP mixer network.
 
@@ -543,6 +544,7 @@ class GrowingMLPMixer(GrowingContainer):
         super().__init__(
             in_features=torch.tensor(in_features).prod().int().item(),
             out_features=out_features,
+            device=device,
         )
         self.device = device
         self.patcher = nn.Conv2d(
@@ -566,14 +568,11 @@ class GrowingMLPMixer(GrowingContainer):
             ]
         )
         self.classifier = nn.Linear(num_features, self.out_features, device=self.device)
-        self.set_growing_layers()
-
-    def set_growing_layers(self) -> None:
-        """Reference all growable layers of the model in the _growing_layers private attribute"""
-        self._growing_layers = list()
+        self._growable_layers = []
         for mixer in self.mixers:
-            self._growing_layers.append(mixer.token_mixer.mlp.second_layer)
-            self._growing_layers.append(mixer.channel_mixer.mlp.second_layer)
+            self._growable_layers.append(mixer.token_mixer.mlp.second_layer)
+            self._growable_layers.append(mixer.channel_mixer.mlp.second_layer)
+        self.set_growing_layers(scheduling_method="all")
 
     def forward(self, x: Tensor) -> Tensor:
         """

--- a/src/gromo/containers/growing_residual_mlp.py
+++ b/src/gromo/containers/growing_residual_mlp.py
@@ -9,6 +9,7 @@ import torch.nn as nn
 from torch import Tensor
 
 from gromo.containers.growing_container import GrowingContainer
+from gromo.containers.sequential_growing_container import SequentialGrowingModel
 from gromo.modules.linear_growing_module import LinearGrowingModule
 from gromo.utils.utils import compute_tensor_stats
 
@@ -166,7 +167,7 @@ class GrowingResidualBlock(GrowingContainer):
         return layer_information
 
 
-class GrowingResidualMLP(GrowingContainer):
+class GrowingResidualMLP(SequentialGrowingModel):
     """Represent a Residual MLP
 
     Parameters
@@ -230,11 +231,8 @@ class GrowingResidualMLP(GrowingContainer):
 
         # final projection
         self.projection = nn.Linear(num_features, out_features, device=self.device)
-        self.set_growing_layers()
-
-    def set_growing_layers(self):
-        """Reference all growable layers of the model in the _growing_layers private attribute"""
-        self._growing_layers = [block.second_layer for block in self.blocks]
+        self._growable_layers = [block.second_layer for block in self.blocks]
+        self.set_growing_layers(scheduling_method="all")
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Forward function

--- a/tests/test_growing_mlp.py
+++ b/tests/test_growing_mlp.py
@@ -74,10 +74,10 @@ class TestGrowingMLP(TorchTestCase):
         # Initially, all layers should be growing
         self.assertEqual(len(self.model._growing_layers), self.number_hidden_layers)
         # Set only the second layer to be growing
-        self.model.set_growing_layers(index=1)
+        self.model.set_growing_layers(index=0)
         self.assertEqual(len(self.model._growing_layers), 1)
         # Set only the third layer to be growing
-        self.model.set_growing_layers(index=2)
+        self.model.set_growing_layers(index=1)
         self.assertEqual(len(self.model._growing_layers), 1)
         # Set all layers to be growing again
         self.model.set_growing_layers()

--- a/tests/test_growing_mlp.py
+++ b/tests/test_growing_mlp.py
@@ -74,10 +74,10 @@ class TestGrowingMLP(TorchTestCase):
         # Initially, all layers should be growing
         self.assertEqual(len(self.model._growing_layers), self.number_hidden_layers)
         # Set only the second layer to be growing
-        self.model.set_growing_layers(1)
+        self.model.set_growing_layers(index=1)
         self.assertEqual(len(self.model._growing_layers), 1)
         # Set only the third layer to be growing
-        self.model.set_growing_layers(2)
+        self.model.set_growing_layers(index=2)
         self.assertEqual(len(self.model._growing_layers), 1)
         # Set all layers to be growing again
         self.model.set_growing_layers()


### PR DESCRIPTION
This PR refactors the growing MLP containers by turning them into `SequentialGrowingContainer` objects.

The goal is to simplify the implementation of functions manipulating the models by avoiding architecture-specific case distinctions.

* Refactored:

  * `growing_mlp.py`
  * `growing_mlp_mixer.py`
  * `growing_residual_mlp.py`
* Converted the corresponding model structures to `SequentialGrowingContainer`.

This makes downstream model manipulation code cleaner and more generic.
