### PR TITLE
add prune_layer support to GrowingModule

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,9 +10,9 @@ from datetime import datetime
 import matplotlib
 import sphinx_gallery  # noqa
 from numpydoc import docscrape, numpydoc  # noqa
-from sphinx_gallery.sorting import FileNameSortKey  # noqa
+from sphinx_gallery.sorting import FileNameSortKey
 
-import gromo  # noqa
+import gromo
 
 
 sys.path.insert(0, os.path.abspath("../"))
@@ -68,7 +68,7 @@ extensions = [
 ]
 
 
-def linkcode_resolve(domain, info):  # noqa: C901
+def linkcode_resolve(domain, info):
     """Determine the URL corresponding to a Python object.
 
     Parameters

--- a/docs/source/sphinxext/gh_substitutions.py
+++ b/docs/source/sphinxext/gh_substitutions.py
@@ -6,7 +6,7 @@ from docutils.parsers.rst.roles import set_classes
 # https://doughellmann.com/blog/2010/05/09/defining-custom-roles-in-sphinx/
 
 
-def gh_role(name, rawtext, text, lineno, inliner, options={}, content=[]):  # noqa: B006
+def gh_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     """Link to a GitHub issue."""
     try:
         # issue/PR mode (issues/PR-num will redirect to pull/PR-num)

--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -20,6 +20,7 @@ Develop branch
 Enhancements
 ~~~~~~~~~~~~
 
+- Add prune layer support to ``GrowingModule``, ``LinearGrowingModule``, ``Conv2dGrowingModule``, and growing normalisation layers to shrink layers along features/channels (:gh:`258` by `Ying jin`_).
 - Add Kaiming-normal and copy-normal initializations for layer extensions: ``kaiming_initialization`` and ``copy_initialization_variance`` (renamed from ``copy_uniform_initialization``) gain a ``distribution`` argument, exposed through the new ``"kaiming_normal"`` and ``"copy_normal"`` keys of ``create_layer_extensions`` (:gh:`259` by `Théo Rudkiewicz`_).
 - Refactored growing MLP containers to use `SequentialGrowingContainer` for a more unified model manipulation interface (:gh:`253` by `Pako Maxence TEKOU`_)
 - Example for `GrowingGraphNetwork` and `GrowingDAG` usage (:gh:`252` by `Stella Douka`_)
@@ -146,3 +147,4 @@ API changes
 .. _Hugo Mousset: https://github.com/hmousset
 .. _ferdinandlouapre: https://github.com/ferdinandlouapre
 .. _Pako Maxence TEKOU: https://github.com/maxencelebaron
+.. _Ying jin: https://github.com/PineappleBlowsnow

--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -2,6 +2,7 @@ import types
 from math import prod
 from warnings import warn
 
+import numpy as np
 import torch
 
 from gromo.modules.growing_module import GrowingModule, MergeGrowingModule
@@ -1237,11 +1238,24 @@ class Conv2dGrowingModule(GrowingModule):
         )
 
     @torch.no_grad()
-    def prune_layer_in(self, indices_to_remove: list[int]) -> None:
+    def prune_layer_in(self, indices_to_remove: np.ndarray | list[int]) -> None:
         """Shrink "self.layer" by dropping the input channels."""
-        keep = [i for i in range(self.in_channels) if i not in set(indices_to_remove)]
+        if self.layer.groups != 1:
+            raise NotImplementedError("Pruning is only supported for Conv2d layers with groups == 1.")
+
+        if isinstance(indices_to_remove, list):
+            indices_to_remove = np.array(indices_to_remove)
+        elif not isinstance(indices_to_remove, np.ndarray):
+            raise TypeError("indices_to_remove must be a numpy.ndarray or a list")
+        if not np.issubdtype(indices_to_remove.dtype, np.integer):
+            raise TypeError("indices_to_remove must contain integers")
+
         device = self.layer.weight.device
-        keep_idx = torch.tensor(keep, device=device, dtype=torch.long)
+        keep = np.setdiff1d(np.arange(self.in_channels), indices_to_remove)
+        keep_idx = torch.from_numpy(keep).to(device=device, dtype=torch.long)
+
+        weight_requires_grad = self.layer.weight.requires_grad
+        bias_requires_grad = self.layer.bias.requires_grad if self.layer.bias is not None else False
 
         new_layer = torch.nn.Conv2d(
             in_channels=len(keep),
@@ -1255,9 +1269,15 @@ class Conv2dGrowingModule(GrowingModule):
             padding_mode=self.layer.padding_mode,
             device=device,
         )
-        new_layer.weight.data = self.layer.weight.index_select(1, keep_idx).clone()
+        new_layer.weight = torch.nn.Parameter(
+            self.layer.weight.index_select(1, keep_idx).clone(),
+            requires_grad=weight_requires_grad
+        )
         if self.layer.bias is not None:
-            new_layer.bias.data = self.layer.bias.clone()
+            new_layer.bias = torch.nn.Parameter(
+                self.layer.bias.clone(),
+                requires_grad=bias_requires_grad
+            )
 
         self.layer = new_layer
 
@@ -1277,11 +1297,24 @@ class Conv2dGrowingModule(GrowingModule):
         )
 
     @torch.no_grad()
-    def prune_layer_out(self, indices_to_remove: list[int]) -> None:
-        """Shrink "self.layer"by dropping the output channels."""
-        keep = [i for i in range(self.out_features) if i not in set(indices_to_remove)]
+    def prune_layer_out(self, indices_to_remove: np.ndarray | list[int]) -> None:
+        """Shrink "self.layer" by dropping the output channels."""
+        if self.layer.groups != 1:
+            raise NotImplementedError("Pruning is only supported for Conv2d layers with groups == 1.")
+
+        if isinstance(indices_to_remove, list):
+            indices_to_remove = np.array(indices_to_remove)
+        elif not isinstance(indices_to_remove, np.ndarray):
+            raise TypeError("indices_to_remove must be a numpy.ndarray or a list")
+        if not np.issubdtype(indices_to_remove.dtype, np.integer):
+            raise TypeError("indices_to_remove must contain integers")
+
         device = self.layer.weight.device
-        keep_idx = torch.tensor(keep, device=device, dtype=torch.long)
+        keep = np.setdiff1d(np.arange(self.out_channels), indices_to_remove)
+        keep_idx = torch.from_numpy(keep).to(device=device, dtype=torch.long)
+
+        weight_requires_grad = self.layer.weight.requires_grad
+        bias_requires_grad = self.layer.bias.requires_grad if self.layer.bias is not None else False
 
         new_layer = torch.nn.Conv2d(
             in_channels=self.in_channels,
@@ -1295,9 +1328,15 @@ class Conv2dGrowingModule(GrowingModule):
             padding_mode=self.layer.padding_mode,
             device=device,
         )
-        new_layer.weight.data = self.layer.weight.index_select(0, keep_idx).clone()
+        new_layer.weight = torch.nn.Parameter(
+            self.layer.weight.index_select(0, keep_idx).clone(),
+            requires_grad=weight_requires_grad
+        )
         if self.layer.bias is not None:
-            new_layer.bias.data = self.layer.bias.index_select(0, keep_idx).clone()
+            new_layer.bias = torch.nn.Parameter(
+                self.layer.bias.index_select(0, keep_idx).clone(),
+                requires_grad=bias_requires_grad
+            )
 
         self.layer = new_layer
 

--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -1241,7 +1241,9 @@ class Conv2dGrowingModule(GrowingModule):
     def prune_layer_in(self, indices_to_remove: np.ndarray | list[int]) -> None:
         """Shrink "self.layer" by dropping the input channels."""
         if self.layer.groups != 1:
-            raise NotImplementedError("Pruning is only supported for Conv2d layers with groups == 1.")
+            raise NotImplementedError(
+                "Pruning is only supported for Conv2d layers with groups == 1."
+            )
 
         if isinstance(indices_to_remove, list):
             indices_to_remove = np.array(indices_to_remove)
@@ -1255,7 +1257,9 @@ class Conv2dGrowingModule(GrowingModule):
         keep_idx = torch.from_numpy(keep).to(device=device, dtype=torch.long)
 
         weight_requires_grad = self.layer.weight.requires_grad
-        bias_requires_grad = self.layer.bias.requires_grad if self.layer.bias is not None else False
+        bias_requires_grad = (
+            self.layer.bias.requires_grad if self.layer.bias is not None else False
+        )
 
         new_layer = torch.nn.Conv2d(
             in_channels=len(keep),
@@ -1271,12 +1275,11 @@ class Conv2dGrowingModule(GrowingModule):
         )
         new_layer.weight = torch.nn.Parameter(
             self.layer.weight.index_select(1, keep_idx).clone(),
-            requires_grad=weight_requires_grad
+            requires_grad=weight_requires_grad,
         )
         if self.layer.bias is not None:
             new_layer.bias = torch.nn.Parameter(
-                self.layer.bias.clone(),
-                requires_grad=bias_requires_grad
+                self.layer.bias.clone(), requires_grad=bias_requires_grad
             )
 
         self.layer = new_layer
@@ -1300,7 +1303,9 @@ class Conv2dGrowingModule(GrowingModule):
     def prune_layer_out(self, indices_to_remove: np.ndarray | list[int]) -> None:
         """Shrink "self.layer" by dropping the output channels."""
         if self.layer.groups != 1:
-            raise NotImplementedError("Pruning is only supported for Conv2d layers with groups == 1.")
+            raise NotImplementedError(
+                "Pruning is only supported for Conv2d layers with groups == 1."
+            )
 
         if isinstance(indices_to_remove, list):
             indices_to_remove = np.array(indices_to_remove)
@@ -1314,7 +1319,9 @@ class Conv2dGrowingModule(GrowingModule):
         keep_idx = torch.from_numpy(keep).to(device=device, dtype=torch.long)
 
         weight_requires_grad = self.layer.weight.requires_grad
-        bias_requires_grad = self.layer.bias.requires_grad if self.layer.bias is not None else False
+        bias_requires_grad = (
+            self.layer.bias.requires_grad if self.layer.bias is not None else False
+        )
 
         new_layer = torch.nn.Conv2d(
             in_channels=self.in_channels,
@@ -1330,12 +1337,12 @@ class Conv2dGrowingModule(GrowingModule):
         )
         new_layer.weight = torch.nn.Parameter(
             self.layer.weight.index_select(0, keep_idx).clone(),
-            requires_grad=weight_requires_grad
+            requires_grad=weight_requires_grad,
         )
         if self.layer.bias is not None:
             new_layer.bias = torch.nn.Parameter(
                 self.layer.bias.index_select(0, keep_idx).clone(),
-                requires_grad=bias_requires_grad
+                requires_grad=bias_requires_grad,
             )
 
         self.layer = new_layer

--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -1235,34 +1235,30 @@ class Conv2dGrowingModule(GrowingModule):
             update_function=self.compute_m_update,
             name=self.tensor_m.name,
         )
-    
-
-
 
     @torch.no_grad()
-    def prune_layer_in(self, indices_to_remove:list[int])->None:
-        """ Shrink "self.layer" by dropping the input channels."""
+    def prune_layer_in(self, indices_to_remove: list[int]) -> None:
+        """Shrink "self.layer" by dropping the input channels."""
         keep = [i for i in range(self.in_channels) if i not in set(indices_to_remove)]
         device = self.layer.weight.device
-        keep_idx = torch.tensor(keep, device=device, dtype = torch.long)
+        keep_idx = torch.tensor(keep, device=device, dtype=torch.long)
 
         new_layer = torch.nn.Conv2d(
-            in_channels = len(keep),
-            out_channels= self.out_channels,
-            kernel_size = self.layer.kernel_size,
-            stride = self.layer.stride,
-            padding = self.layer.padding,
-            dilation =self.layer.dilation,
-            groups = self.layer.groups,
-            bias = (self.layer.bias is not None),
-            padding_mode = self.layer.padding_mode,
-            device = device,
-
+            in_channels=len(keep),
+            out_channels=self.out_channels,
+            kernel_size=self.layer.kernel_size,
+            stride=self.layer.stride,
+            padding=self.layer.padding,
+            dilation=self.layer.dilation,
+            groups=self.layer.groups,
+            bias=(self.layer.bias is not None),
+            padding_mode=self.layer.padding_mode,
+            device=device,
         )
-        new_layer.weight.data =self.layer.weight.index_select(1,keep_idx).clone()
+        new_layer.weight.data = self.layer.weight.index_select(1, keep_idx).clone()
         if self.layer.bias is not None:
             new_layer.bias.data = self.layer.bias.clone()
-        
+
         self.layer = new_layer
 
         in_dim = (
@@ -1280,31 +1276,29 @@ class Conv2dGrowingModule(GrowingModule):
             name=self.tensor_m.name,
         )
 
-
-
     @torch.no_grad()
-    def prune_layer_out(self, indices_to_remove:list[int])->None:
-        """ Shrink "self.layer"by dropping the output channels."""
+    def prune_layer_out(self, indices_to_remove: list[int]) -> None:
+        """Shrink "self.layer"by dropping the output channels."""
         keep = [i for i in range(self.out_features) if i not in set(indices_to_remove)]
         device = self.layer.weight.device
-        keep_idx = torch.tensor(keep, device=device, dtype = torch.long)
+        keep_idx = torch.tensor(keep, device=device, dtype=torch.long)
 
         new_layer = torch.nn.Conv2d(
-            in_channels = self.in_channels,
-            out_channels = len(keep),
-            kernel_size = self.layer.kernel_size,
-            stride = self.layer.stride,
-            padding = self.layer.padding,
-            dilation =self.layer.dilation,
-            groups = self.layer.groups,
-            bias = (self.layer.bias is not None),
-            padding_mode = self.layer.padding_mode,
-            device = device,
+            in_channels=self.in_channels,
+            out_channels=len(keep),
+            kernel_size=self.layer.kernel_size,
+            stride=self.layer.stride,
+            padding=self.layer.padding,
+            dilation=self.layer.dilation,
+            groups=self.layer.groups,
+            bias=(self.layer.bias is not None),
+            padding_mode=self.layer.padding_mode,
+            device=device,
         )
-        new_layer.weight.data = self.layer.weight.index_select(0,keep_idx).clone()
+        new_layer.weight.data = self.layer.weight.index_select(0, keep_idx).clone()
         if self.layer.bias is not None:
-            new_layer.bias.data = self.layer.bias.index_select(0,keep_idx).clone()
-        
+            new_layer.bias.data = self.layer.bias.index_select(0, keep_idx).clone()
+
         self.layer = new_layer
 
         in_dim = (
@@ -1316,7 +1310,6 @@ class Conv2dGrowingModule(GrowingModule):
             update_function=self.compute_m_update,
             name=self.tensor_m.name,
         )
-
 
     def update_input_size(  # type: ignore
         self,

--- a/src/gromo/modules/conv2d_growing_module.py
+++ b/src/gromo/modules/conv2d_growing_module.py
@@ -1235,6 +1235,88 @@ class Conv2dGrowingModule(GrowingModule):
             update_function=self.compute_m_update,
             name=self.tensor_m.name,
         )
+    
+
+
+
+    @torch.no_grad()
+    def prune_layer_in(self, indices_to_remove:list[int])->None:
+        """ Shrink "self.layer" by dropping the input channels."""
+        keep = [i for i in range(self.in_channels) if i not in set(indices_to_remove)]
+        device = self.layer.weight.device
+        keep_idx = torch.tensor(keep, device=device, dtype = torch.long)
+
+        new_layer = torch.nn.Conv2d(
+            in_channels = len(keep),
+            out_channels= self.out_channels,
+            kernel_size = self.layer.kernel_size,
+            stride = self.layer.stride,
+            padding = self.layer.padding,
+            dilation =self.layer.dilation,
+            groups = self.layer.groups,
+            bias = (self.layer.bias is not None),
+            padding_mode = self.layer.padding_mode,
+            device = device,
+
+        )
+        new_layer.weight.data =self.layer.weight.index_select(1,keep_idx).clone()
+        if self.layer.bias is not None:
+            new_layer.bias.data = self.layer.bias.clone()
+        
+        self.layer = new_layer
+
+        in_dim = (
+            self.in_channels * self.layer.kernel_size[0] * self.layer.kernel_size[1]
+            + self.use_bias
+        )
+        self._tensor_s = TensorStatistic(
+            (in_dim, in_dim),
+            update_function=self.compute_s_update,
+            name=self.tensor_s.name,
+        )
+        self.tensor_m = TensorStatistic(
+            (in_dim, self.out_channels),
+            update_function=self.compute_m_update,
+            name=self.tensor_m.name,
+        )
+
+
+
+    @torch.no_grad()
+    def prune_layer_out(self, indices_to_remove:list[int])->None:
+        """ Shrink "self.layer"by dropping the output channels."""
+        keep = [i for i in range(self.out_features) if i not in set(indices_to_remove)]
+        device = self.layer.weight.device
+        keep_idx = torch.tensor(keep, device=device, dtype = torch.long)
+
+        new_layer = torch.nn.Conv2d(
+            in_channels = self.in_channels,
+            out_channels = len(keep),
+            kernel_size = self.layer.kernel_size,
+            stride = self.layer.stride,
+            padding = self.layer.padding,
+            dilation =self.layer.dilation,
+            groups = self.layer.groups,
+            bias = (self.layer.bias is not None),
+            padding_mode = self.layer.padding_mode,
+            device = device,
+        )
+        new_layer.weight.data = self.layer.weight.index_select(0,keep_idx).clone()
+        if self.layer.bias is not None:
+            new_layer.bias.data = self.layer.bias.index_select(0,keep_idx).clone()
+        
+        self.layer = new_layer
+
+        in_dim = (
+            self.in_channels * self.layer.kernel_size[0] * self.layer.kernel_size[1]
+            + self.use_bias
+        )
+        self.tensor_m = TensorStatistic(
+            (in_dim, self.out_channels),
+            update_function=self.compute_m_update,
+            name=self.tensor_m.name,
+        )
+
 
     def update_input_size(  # type: ignore
         self,

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -3904,7 +3904,13 @@ class GrowingModule(torch.nn.Module):
 
         Parameters
         ----------
-        indices: np.ndarray clean prune list, already validated and sorted
+        indices : np.ndarray
+            Clean prune list, already validated and sorted.
+
+        Raises
+        ------
+        TypeError
+            If the module is not a passthrough module and does not support pruning.
         """
         post_fn = self.previous_module.post_layer_function
         if post_fn is not None:

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -4,6 +4,8 @@ from typing import Any, Iterator, Literal, Protocol, get_args, runtime_checkable
 
 import numpy as np
 import torch
+import torch.nn.modules.activation as activation_mod
+import torch.nn.modules.dropout as dropout_mod
 
 from gromo.config.loader import load_config
 from gromo.utils.tensor_statistic import TensorStatistic
@@ -717,11 +719,8 @@ class SupportsExtendedForward(Protocol):
         ...
 
 
-import torch.nn.modules.activation as activation_mod
-import torch.nn.modules.dropout as dropout_mod
-
-
 def is_passthrough(module: torch.nn.Module) -> bool:
+    """Check if a module is a passthrough layer (no learnable parameters/buffers)."""
     cls = module.__class__
     if cls is torch.nn.Identity:
         return True
@@ -731,7 +730,9 @@ def is_passthrough(module: torch.nn.Module) -> bool:
         cls.__module__ == activation_mod.__name__
         and len(list(module.parameters(recurse=False))) == 0
         and len(list(module.buffers(recurse=False))) == 0
-        and not isinstance(module, (torch.nn.PReLU, torch.nn.MultiheadAttention, torch.nn.GLU))
+        and not isinstance(
+            module, (torch.nn.PReLU, torch.nn.MultiheadAttention, torch.nn.GLU)
+        )
     )
 
 
@@ -3863,8 +3864,8 @@ class GrowingModule(torch.nn.Module):
         indices_to_remove: list[int] | np.ndarray,
     ) -> None:
         """
-        Prune fan-in neurons 
-        """ 
+        Prune fan-in neurons
+        """
         # Need a previous GrowingModule to coordinate with.
         if not isinstance(self.previous_module, GrowingModule):
             raise TypeError(
@@ -3901,9 +3902,10 @@ class GrowingModule(torch.nn.Module):
     def _prune_post_layer_function(self, indices: np.ndarray) -> None:
         """Prune the post-layer function of the previous module, if it exists.
 
-        Parameters:
-        indices: np.ndarray clean prune list, already validated and sorted"""
-
+        Parameters
+        ----------
+        indices: np.ndarray clean prune list, already validated and sorted
+        """
         post_fn = self.previous_module.post_layer_function
         if post_fn is not None:
             sub_modules = (

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -717,6 +717,24 @@ class SupportsExtendedForward(Protocol):
         ...
 
 
+import torch.nn.modules.activation as activation_mod
+import torch.nn.modules.dropout as dropout_mod
+
+
+def is_passthrough(module: torch.nn.Module) -> bool:
+    cls = module.__class__
+    if cls is torch.nn.Identity:
+        return True
+    if cls.__module__ == dropout_mod.__name__:
+        return True
+    return (
+        cls.__module__ == activation_mod.__name__
+        and len(list(module.parameters(recurse=False))) == 0
+        and len(list(module.buffers(recurse=False))) == 0
+        and not isinstance(module, (torch.nn.PReLU, torch.nn.MultiheadAttention, torch.nn.GLU))
+    )
+
+
 class GrowingModule(torch.nn.Module):
     """
     Abstract class for a Module of dynamic size
@@ -3840,33 +3858,32 @@ class GrowingModule(torch.nn.Module):
         )
 
     @torch.no_grad()
-    def prune_hidden_neurons_in(
+    def prune_neurons_in(
         self,
-        indices_to_remove: list[int],
+        indices_to_remove: list[int] | np.ndarray,
     ) -> None:
         """
-        Prune neurons from the hidden dim between ``self.previous_module`` and ``self``.
+        Prune fan-in neurons 
+        """ 
+        # Need a previous GrowingModule to coordinate with.
+        if not isinstance(self.previous_module, GrowingModule):
+            raise TypeError(
+                f"prune_neurons_in requires a previous GrowingModule, "
+                f"got {type(self.previous_module)}"
+            )
 
-        Symmetric counterpart of ``create_layer_extensions``: shrinks the hidden
-        dimension by dropping rows from ``previous_module.weight`` and the
-        matching columns from ``self.weight``.
+        # make sure indices are a numpy array of integers
+        if isinstance(indices_to_remove, list):
+            indices_to_remove = np.array(indices_to_remove)
+        elif not isinstance(indices_to_remove, np.ndarray):
+            raise TypeError("indices_to_remove must be a numpy.ndarray or a list")
+        if not np.issubdtype(indices_to_remove.dtype, np.integer):
+            raise TypeError("indices_to_remove must contain integers")
 
-        Parameters
-        ----------
-        indices_to_remove: list[int]
-            Hidden-dim indices to delete. De-duplicated and sorted internally.
-            Empty list leads to no-operation; out-of-range raises IndexError.
-        """
-        # 0) Need a previous GrowingModule to coordinate with.
-        assert isinstance(self.previous_module, GrowingModule), (
-            f"prune_hidden_neurons_in requires a previous GrowingModule, "
-            f"got {type(self.previous_module)}"
-        )
-
-        # 1) Normalize + validate indices.
-        if len(indices_to_remove) == 0:
+        # Normalize + validate indices.
+        if indices_to_remove.size == 0:
             return
-        indices = sorted({int(i) for i in indices_to_remove})
+        indices = np.unique(indices_to_remove)
         n_hidden = self.previous_module.out_features
         if indices[0] < 0 or indices[-1] >= n_hidden:
             raise IndexError(
@@ -3875,17 +3892,17 @@ class GrowingModule(torch.nn.Module):
         if len(indices) == n_hidden:
             raise ValueError("Cannot prune all neurons of a layer")
 
-        # 2) Drop matching dims on both sides. Subclasses implement the slicing.
-        self.previous_module.prune_layer_out(indices)  # rows of W_prev， reshape tensor m
+        # Drop matching dims on both sides. Subclasses implement the slicing.
+        self.previous_module.prune_layer_out(indices)  # rows of W_prev
         self._prune_post_layer_function(indices)  # post-layer of the previous module
-        self.prune_layer_in(indices)  # cols of W_self, reshape tensor m and s
+        self.prune_layer_in(indices)  # cols of W_self
 
     @torch.no_grad()
-    def _prune_post_layer_function(self, indices: list[int]) -> None:
-        """Prune the post-layer function of the previous module, if it exists and has num_features.
+    def _prune_post_layer_function(self, indices: np.ndarray) -> None:
+        """Prune the post-layer function of the previous module, if it exists.
 
         Parameters:
-        indices: list[int] clean prune list, already validated and sorted"""
+        indices: np.ndarray clean prune list, already validated and sorted"""
 
         post_fn = self.previous_module.post_layer_function
         if post_fn is not None:
@@ -3893,33 +3910,15 @@ class GrowingModule(torch.nn.Module):
                 list(post_fn) if isinstance(post_fn, torch.nn.Sequential) else [post_fn]
             )
             for m in sub_modules:
-                if not hasattr(
-                    m, "num_features"
-                ):  # skip modules that don't have num_features (e.g. ReLU)
+                if is_passthrough(m):
                     continue
-
-                device = (
-                    m.weight.device
-                    if isinstance(getattr(m, "weight", None), torch.nn.Parameter)
-                    else (
-                        m.running_mean.device
-                        if getattr(m, "running_mean", None) is not None
-                        else "cpu"
+                # If the module has a prune method, call it.
+                if hasattr(m, "prune") and callable(m.prune):
+                    m.prune(indices)
+                else:
+                    raise TypeError(
+                        f"Module {type(m)} is not a passthrough module and does not support pruning (no prune method)."
                     )
-                )
-
-                keep_mask = torch.ones(m.num_features, dtype=torch.bool, device=device)
-
-                keep_mask[indices] = False
-                if isinstance(getattr(m, "weight", None), torch.nn.Parameter):
-                    m.weight = torch.nn.Parameter(m.weight[keep_mask].clone())
-                if isinstance(getattr(m, "bias", None), torch.nn.Parameter):
-                    m.bias = torch.nn.Parameter(m.bias[keep_mask].clone())
-                if getattr(m, "running_mean", None) is not None:
-                    m.running_mean = m.running_mean[keep_mask].clone()
-                if getattr(m, "running_var", None) is not None:
-                    m.running_var = m.running_var[keep_mask].clone()
-                m.num_features = int(keep_mask.sum().item())
 
     def missing_neurons(self) -> int:
         """

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -3839,6 +3839,81 @@ class GrowingModule(torch.nn.Module):
             noise_ratio=noise_ratio,
         )
 
+    @torch.no_grad()
+    def prune_hidden_neurons_in(
+        self,
+        indices_to_remove: list[int],
+        ) -> None:
+        """
+        Prune neurons from the hidden dim between ``self.previous_module`` and ``self``.
+
+        Symmetric counterpart of ``create_layer_extensions``: shrinks the hidden
+        dimension by dropping rows from ``previous_module.weight`` and the
+        matching columns from ``self.weight``.
+
+        Parameters
+        ----------
+        indices_to_remove: list[int]
+            Hidden-dim indices to delete. De-duplicated and sorted internally.
+            Empty list leads to no-operation; out-of-range raises IndexError.
+        """
+        # 0) Need a previous GrowingModule to coordinate with.
+        assert isinstance(self.previous_module, GrowingModule), (
+            f"prune_hidden_neurons_in requires a previous GrowingModule, "
+            f"got {type(self.previous_module)}"
+        )
+
+        # 1) Normalize + validate indices.
+        if len(indices_to_remove) == 0:
+            return
+        indices = sorted({int(i) for i in indices_to_remove})
+        n_hidden = self.previous_module.out_features
+        if indices[0] < 0 or indices[-1] >= n_hidden:
+            raise IndexError(
+                f"indices {indices} out of range for hidden dim of size {n_hidden}"
+            )
+        if len(indices) == n_hidden:
+            raise ValueError("Cannot prune all neurons of a layer")
+
+        # 2) Drop matching dims on both sides. Subclasses implement the slicing.
+        self.previous_module.prune_layer_out(indices)   # rows of W_prev， reshape tensor m
+        self._prune_post_layer_function(indices) # post-layer of the previous module
+        self.prune_layer_in(indices)                    # cols of W_self, reshape tensor m and s
+
+    
+
+
+    @torch.no_grad()
+    def _prune_post_layer_function(self, indices: list[int]) -> None:
+        """Prune the post-layer function of the previous module, if it exists and has num_features.
+
+        Parameters:
+        indices: list[int] clean prune list, already validated and sorted"""
+
+        post_fn = self.previous_module.post_layer_function
+        if post_fn is not None:
+            sub_modules = list(post_fn) if isinstance(post_fn, torch.nn.Sequential) else [post_fn]
+            for m in sub_modules:
+                if not hasattr(m, "num_features"): # skip modules that don't have num_features (e.g. ReLU)
+                    continue
+                
+                device = m.weight.device if isinstance(getattr(m, "weight", None), torch.nn.Parameter) else ( m.running_mean.device if getattr(m, "running_mean", None) is not None else "cpu")
+
+                keep_mask = torch.ones(m.num_features, dtype=torch.bool, device=device)
+
+                keep_mask[indices] = False
+                if isinstance(getattr(m, "weight", None), torch.nn.Parameter):
+                    m.weight = torch.nn.Parameter(m.weight[keep_mask].clone())
+                if isinstance(getattr(m, "bias", None), torch.nn.Parameter):
+                    m.bias = torch.nn.Parameter(m.bias[keep_mask].clone())
+                if getattr(m, "running_mean", None) is not None:
+                    m.running_mean = m.running_mean[keep_mask].clone()
+                if getattr(m, "running_var", None) is not None:
+                    m.running_var = m.running_var[keep_mask].clone()
+                m.num_features = int(keep_mask.sum().item())
+
+
+
     def missing_neurons(self) -> int:
         """
         Get the number of missing neurons to reach the target hidden features.

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -3843,7 +3843,7 @@ class GrowingModule(torch.nn.Module):
     def prune_hidden_neurons_in(
         self,
         indices_to_remove: list[int],
-        ) -> None:
+    ) -> None:
         """
         Prune neurons from the hidden dim between ``self.previous_module`` and ``self``.
 
@@ -3876,12 +3876,9 @@ class GrowingModule(torch.nn.Module):
             raise ValueError("Cannot prune all neurons of a layer")
 
         # 2) Drop matching dims on both sides. Subclasses implement the slicing.
-        self.previous_module.prune_layer_out(indices)   # rows of W_prev， reshape tensor m
-        self._prune_post_layer_function(indices) # post-layer of the previous module
-        self.prune_layer_in(indices)                    # cols of W_self, reshape tensor m and s
-
-    
-
+        self.previous_module.prune_layer_out(indices)  # rows of W_prev， reshape tensor m
+        self._prune_post_layer_function(indices)  # post-layer of the previous module
+        self.prune_layer_in(indices)  # cols of W_self, reshape tensor m and s
 
     @torch.no_grad()
     def _prune_post_layer_function(self, indices: list[int]) -> None:
@@ -3892,12 +3889,24 @@ class GrowingModule(torch.nn.Module):
 
         post_fn = self.previous_module.post_layer_function
         if post_fn is not None:
-            sub_modules = list(post_fn) if isinstance(post_fn, torch.nn.Sequential) else [post_fn]
+            sub_modules = (
+                list(post_fn) if isinstance(post_fn, torch.nn.Sequential) else [post_fn]
+            )
             for m in sub_modules:
-                if not hasattr(m, "num_features"): # skip modules that don't have num_features (e.g. ReLU)
+                if not hasattr(
+                    m, "num_features"
+                ):  # skip modules that don't have num_features (e.g. ReLU)
                     continue
-                
-                device = m.weight.device if isinstance(getattr(m, "weight", None), torch.nn.Parameter) else ( m.running_mean.device if getattr(m, "running_mean", None) is not None else "cpu")
+
+                device = (
+                    m.weight.device
+                    if isinstance(getattr(m, "weight", None), torch.nn.Parameter)
+                    else (
+                        m.running_mean.device
+                        if getattr(m, "running_mean", None) is not None
+                        else "cpu"
+                    )
+                )
 
                 keep_mask = torch.ones(m.num_features, dtype=torch.bool, device=device)
 
@@ -3911,8 +3920,6 @@ class GrowingModule(torch.nn.Module):
                 if getattr(m, "running_var", None) is not None:
                     m.running_var = m.running_var[keep_mask].clone()
                 m.num_features = int(keep_mask.sum().item())
-
-
 
     def missing_neurons(self) -> int:
         """

--- a/src/gromo/modules/growing_normalisation.py
+++ b/src/gromo/modules/growing_normalisation.py
@@ -2,6 +2,7 @@
 
 from typing import Callable, Literal, TypeAlias, TypedDict
 
+import numpy as np
 import torch
 import torch.nn as nn
 
@@ -315,6 +316,60 @@ class GrowingBatchNorm(nn.modules.batchnorm._BatchNorm):
         """
         return f"{super().extra_repr()}, name={self.name}"
 
+    @torch.no_grad()
+    def prune(self, indices_to_remove: np.ndarray | list[int]) -> None:
+        """
+        Prune the batch normalization layer by removing specified features.
+
+        Parameters
+        ----------
+        indices_to_remove : np.ndarray | list[int]
+            Feature indices to remove.
+        """
+        if isinstance(indices_to_remove, list):
+            indices_to_remove = np.array(indices_to_remove)
+        elif not isinstance(indices_to_remove, np.ndarray):
+            raise TypeError("indices_to_remove must be a numpy.ndarray or a list")
+        if not np.issubdtype(indices_to_remove.dtype, np.integer):
+            raise TypeError("indices_to_remove must contain integers")
+
+        if indices_to_remove.size == 0:
+            return
+
+        # Validate indices
+        indices = np.unique(indices_to_remove)
+        if indices[0] < 0 or indices[-1] >= self.num_features:
+            raise IndexError(
+                f"indices {indices} out of range for num_features {self.num_features}"
+            )
+        if len(indices) == self.num_features:
+            raise ValueError("Cannot prune all features of BatchNorm layer")
+
+        keep_mask = torch.ones(self.num_features, dtype=torch.bool, device=self.weight.device if self.affine else "cpu")
+        keep_mask[indices] = False
+
+        self.num_features = int(keep_mask.sum().item())
+
+        if getattr(self, "affine", False):
+            weight_requires_grad = self.weight.requires_grad
+            bias_requires_grad = self.bias.requires_grad if self.bias is not None else False
+
+            self.weight = nn.Parameter(
+                self.weight[keep_mask].clone(),
+                requires_grad=weight_requires_grad
+            )
+            if self.bias is not None:
+                self.bias = nn.Parameter(
+                    self.bias[keep_mask].clone(),
+                    requires_grad=bias_requires_grad
+                )
+
+        if getattr(self, "track_running_stats", False):
+            if self.running_mean is not None:
+                self.running_mean = self.running_mean[keep_mask].clone()
+            if self.running_var is not None:
+                self.running_var = self.running_var[keep_mask].clone()
+
 
 class GrowingBatchNorm2d(GrowingBatchNorm, nn.BatchNorm2d):
     """
@@ -548,6 +603,58 @@ class GrowingLayerNorm(nn.LayerNorm):
         """
         return f"{super().extra_repr()}, name={self.name}"
 
+    @torch.no_grad()
+    def prune(self, indices_to_remove: np.ndarray | list[int]) -> None:
+        """
+        Prune the LayerNorm layer by removing specified features along the first dimension.
+
+        Parameters
+        ----------
+        indices_to_remove : np.ndarray | list[int]
+            Feature indices to remove.
+        """
+        if isinstance(indices_to_remove, list):
+            indices_to_remove = np.array(indices_to_remove)
+        elif not isinstance(indices_to_remove, np.ndarray):
+            raise TypeError("indices_to_remove must be a numpy.ndarray or a list")
+        if not np.issubdtype(indices_to_remove.dtype, np.integer):
+            raise TypeError("indices_to_remove must contain integers")
+
+        if indices_to_remove.size == 0:
+            return
+
+        old_shape = tuple(int(v) for v in self.normalized_shape)
+        first_dim = old_shape[0]
+
+        # Validate indices
+        indices = np.unique(indices_to_remove)
+        if indices[0] < 0 or indices[-1] >= first_dim:
+            raise IndexError(
+                f"indices {indices} out of range for LayerNorm first dimension {first_dim}"
+            )
+        if len(indices) == first_dim:
+            raise ValueError("Cannot prune all features of LayerNorm layer")
+
+        keep_mask = torch.ones(first_dim, dtype=torch.bool, device=self.weight.device if self.elementwise_affine else "cpu")
+        keep_mask[indices] = False
+
+        new_normalized_shape = (int(keep_mask.sum().item()), *old_shape[1:])
+        self.normalized_shape = new_normalized_shape
+
+        if getattr(self, "elementwise_affine", False):
+            weight_requires_grad = self.weight.requires_grad
+            bias_requires_grad = self.bias.requires_grad if self.bias is not None else False
+
+            self.weight = nn.Parameter(
+                self.weight[keep_mask].clone(),
+                requires_grad=weight_requires_grad
+            )
+            if self.bias is not None:
+                self.bias = nn.Parameter(
+                    self.bias[keep_mask].clone(),
+                    requires_grad=bias_requires_grad
+                )
+
 
 class GrowingGroupNorm(nn.GroupNorm):
     """Growing GroupNorm module.
@@ -744,3 +851,58 @@ class GrowingGroupNorm(nn.GroupNorm):
         Extra representation string for the layer.
         """
         return f"{super().extra_repr()}, name={self.name}"
+
+    @torch.no_grad()
+    def prune(self, indices_to_remove: np.ndarray | list[int]) -> None:
+        """
+        Prune the GroupNorm layer by removing specified channels.
+
+        Parameters
+        ----------
+        indices_to_remove : np.ndarray | list[int]
+            1D array of channel indices to remove.
+        """
+        if isinstance(indices_to_remove, list):
+            indices_to_remove = np.array(indices_to_remove)
+        elif not isinstance(indices_to_remove, np.ndarray):
+            raise TypeError("indices_to_remove must be a numpy.ndarray or a list")
+        if not np.issubdtype(indices_to_remove.dtype, np.integer):
+            raise TypeError("indices_to_remove must contain integers")
+
+        if indices_to_remove.size == 0:
+            return
+
+        # Validate indices
+        indices = np.unique(indices_to_remove)
+        if indices[0] < 0 or indices[-1] >= self.num_channels:
+            raise IndexError(
+                f"indices {indices} out of range for GroupNorm channels {self.num_channels}"
+            )
+        if len(indices) == self.num_channels:
+            raise ValueError("Cannot prune all channels of GroupNorm layer")
+
+        keep_mask = torch.ones(self.num_channels, dtype=torch.bool, device=self.weight.device if self.affine else "cpu")
+        keep_mask[indices] = False
+
+        new_num_channels = int(keep_mask.sum().item())
+        if new_num_channels % self.num_groups != 0:
+            raise ValueError(
+                f"After pruning: num_channels ({new_num_channels}) must be divisible by "
+                f"num_groups ({self.num_groups})."
+            )
+
+        self.num_channels = new_num_channels
+
+        if getattr(self, "affine", False):
+            weight_requires_grad = self.weight.requires_grad
+            bias_requires_grad = self.bias.requires_grad if self.bias is not None else False
+
+            self.weight = nn.Parameter(
+                self.weight[keep_mask].clone(),
+                requires_grad=weight_requires_grad
+            )
+            if self.bias is not None:
+                self.bias = nn.Parameter(
+                    self.bias[keep_mask].clone(),
+                    requires_grad=bias_requires_grad
+                )

--- a/src/gromo/modules/growing_normalisation.py
+++ b/src/gromo/modules/growing_normalisation.py
@@ -325,6 +325,15 @@ class GrowingBatchNorm(nn.modules.batchnorm._BatchNorm):
         ----------
         indices_to_remove : np.ndarray | list[int]
             Feature indices to remove.
+
+        Raises
+        ------
+        TypeError
+            If indices_to_remove is not a numpy.ndarray or a list, or does not contain integers.
+        IndexError
+            If indices are out of range for the number of features.
+        ValueError
+            If attempting to prune all features.
         """
         if isinstance(indices_to_remove, list):
             indices_to_remove = np.array(indices_to_remove)
@@ -616,6 +625,15 @@ class GrowingLayerNorm(nn.LayerNorm):
         ----------
         indices_to_remove : np.ndarray | list[int]
             Feature indices to remove.
+
+        Raises
+        ------
+        TypeError
+            If indices_to_remove is not a numpy.ndarray or a list, or does not contain integers.
+        IndexError
+            If indices are out of range for LayerNorm first dimension.
+        ValueError
+            If attempting to prune all features.
         """
         if isinstance(indices_to_remove, list):
             indices_to_remove = np.array(indices_to_remove)
@@ -869,6 +887,15 @@ class GrowingGroupNorm(nn.GroupNorm):
         ----------
         indices_to_remove : np.ndarray | list[int]
             1D array of channel indices to remove.
+
+        Raises
+        ------
+        TypeError
+            If indices_to_remove is not a numpy.ndarray or a list, or does not contain integers.
+        IndexError
+            If indices are out of range for GroupNorm channels.
+        ValueError
+            If attempting to prune all channels or the pruned channels are not divisible by num_groups.
         """
         if isinstance(indices_to_remove, list):
             indices_to_remove = np.array(indices_to_remove)

--- a/src/gromo/modules/growing_normalisation.py
+++ b/src/gromo/modules/growing_normalisation.py
@@ -345,23 +345,27 @@ class GrowingBatchNorm(nn.modules.batchnorm._BatchNorm):
         if len(indices) == self.num_features:
             raise ValueError("Cannot prune all features of BatchNorm layer")
 
-        keep_mask = torch.ones(self.num_features, dtype=torch.bool, device=self.weight.device if self.affine else "cpu")
+        keep_mask = torch.ones(
+            self.num_features,
+            dtype=torch.bool,
+            device=self.weight.device if self.affine else "cpu",
+        )
         keep_mask[indices] = False
 
         self.num_features = int(keep_mask.sum().item())
 
         if getattr(self, "affine", False):
             weight_requires_grad = self.weight.requires_grad
-            bias_requires_grad = self.bias.requires_grad if self.bias is not None else False
+            bias_requires_grad = (
+                self.bias.requires_grad if self.bias is not None else False
+            )
 
             self.weight = nn.Parameter(
-                self.weight[keep_mask].clone(),
-                requires_grad=weight_requires_grad
+                self.weight[keep_mask].clone(), requires_grad=weight_requires_grad
             )
             if self.bias is not None:
                 self.bias = nn.Parameter(
-                    self.bias[keep_mask].clone(),
-                    requires_grad=bias_requires_grad
+                    self.bias[keep_mask].clone(), requires_grad=bias_requires_grad
                 )
 
         if getattr(self, "track_running_stats", False):
@@ -635,7 +639,11 @@ class GrowingLayerNorm(nn.LayerNorm):
         if len(indices) == first_dim:
             raise ValueError("Cannot prune all features of LayerNorm layer")
 
-        keep_mask = torch.ones(first_dim, dtype=torch.bool, device=self.weight.device if self.elementwise_affine else "cpu")
+        keep_mask = torch.ones(
+            first_dim,
+            dtype=torch.bool,
+            device=self.weight.device if self.elementwise_affine else "cpu",
+        )
         keep_mask[indices] = False
 
         new_normalized_shape = (int(keep_mask.sum().item()), *old_shape[1:])
@@ -643,16 +651,16 @@ class GrowingLayerNorm(nn.LayerNorm):
 
         if getattr(self, "elementwise_affine", False):
             weight_requires_grad = self.weight.requires_grad
-            bias_requires_grad = self.bias.requires_grad if self.bias is not None else False
+            bias_requires_grad = (
+                self.bias.requires_grad if self.bias is not None else False
+            )
 
             self.weight = nn.Parameter(
-                self.weight[keep_mask].clone(),
-                requires_grad=weight_requires_grad
+                self.weight[keep_mask].clone(), requires_grad=weight_requires_grad
             )
             if self.bias is not None:
                 self.bias = nn.Parameter(
-                    self.bias[keep_mask].clone(),
-                    requires_grad=bias_requires_grad
+                    self.bias[keep_mask].clone(), requires_grad=bias_requires_grad
                 )
 
 
@@ -881,7 +889,11 @@ class GrowingGroupNorm(nn.GroupNorm):
         if len(indices) == self.num_channels:
             raise ValueError("Cannot prune all channels of GroupNorm layer")
 
-        keep_mask = torch.ones(self.num_channels, dtype=torch.bool, device=self.weight.device if self.affine else "cpu")
+        keep_mask = torch.ones(
+            self.num_channels,
+            dtype=torch.bool,
+            device=self.weight.device if self.affine else "cpu",
+        )
         keep_mask[indices] = False
 
         new_num_channels = int(keep_mask.sum().item())
@@ -895,14 +907,14 @@ class GrowingGroupNorm(nn.GroupNorm):
 
         if getattr(self, "affine", False):
             weight_requires_grad = self.weight.requires_grad
-            bias_requires_grad = self.bias.requires_grad if self.bias is not None else False
+            bias_requires_grad = (
+                self.bias.requires_grad if self.bias is not None else False
+            )
 
             self.weight = nn.Parameter(
-                self.weight[keep_mask].clone(),
-                requires_grad=weight_requires_grad
+                self.weight[keep_mask].clone(), requires_grad=weight_requires_grad
             )
             if self.bias is not None:
                 self.bias = nn.Parameter(
-                    self.bias[keep_mask].clone(),
-                    requires_grad=bias_requires_grad
+                    self.bias[keep_mask].clone(), requires_grad=bias_requires_grad
                 )

--- a/src/gromo/modules/linear_growing_module.py
+++ b/src/gromo/modules/linear_growing_module.py
@@ -1,6 +1,7 @@
 import types
 from warnings import warn
 
+import numpy as np
 import torch
 
 from gromo.modules.growing_module import GrowingModule, MergeGrowingModule
@@ -1102,7 +1103,7 @@ class LinearGrowingModule(GrowingModule):
         )
 
     @torch.no_grad()
-    def prune_layer_in(self, indices_to_remove: list[int]) -> None:
+    def prune_layer_in(self, indices_to_remove: np.ndarray | list[int]) -> None:
         """
         Shrink ``self.layer`` by dropping the given input columns of its weight.
 
@@ -1110,12 +1111,21 @@ class LinearGrowingModule(GrowingModule):
 
         Parameters
         ----------
-        indices_to_remove: list[int]
-            Column indices in ``self.layer.weight`` to drop. Assumed already
-            de-duplicated, sorted, and in-range by the caller.
+        indices_to_remove: np.ndarray | list[int]
+            Column indices in ``self.layer.weight`` to drop.
         """
-        keep = [i for i in range(self.in_features) if i not in set(indices_to_remove)]
-        keep_idx = torch.tensor(keep, device=self.device, dtype=torch.long)
+        if isinstance(indices_to_remove, list):
+            indices_to_remove = np.array(indices_to_remove)
+        elif not isinstance(indices_to_remove, np.ndarray):
+            raise TypeError("indices_to_remove must be a numpy.ndarray or a list")
+        if not np.issubdtype(indices_to_remove.dtype, np.integer):
+            raise TypeError("indices_to_remove must contain integers")
+
+        keep = np.setdiff1d(np.arange(self.in_features), indices_to_remove)
+        keep_idx = torch.from_numpy(keep).to(device=self.device, dtype=torch.long)
+
+        weight_requires_grad = self.layer.weight.requires_grad
+        bias_requires_grad = self.layer.bias.requires_grad if self.layer.bias is not None else False
 
         new_layer = torch.nn.Linear(
             in_features=len(keep),
@@ -1123,9 +1133,15 @@ class LinearGrowingModule(GrowingModule):
             bias=self.use_bias,
             device=self.device,
         )
-        new_layer.weight.data = self.layer.weight.index_select(1, keep_idx).clone()
+        new_layer.weight = torch.nn.Parameter(
+            self.layer.weight.index_select(1, keep_idx).clone(),
+            requires_grad=weight_requires_grad
+        )
         if self.use_bias:
-            new_layer.bias.data = self.layer.bias.data.clone()  # bias unchanged
+            new_layer.bias = torch.nn.Parameter(
+                self.layer.bias.clone(),
+                requires_grad=bias_requires_grad
+            )
 
         self.layer = new_layer
 
@@ -1142,19 +1158,28 @@ class LinearGrowingModule(GrowingModule):
         )
 
     @torch.no_grad()
-    def prune_layer_out(self, indices_to_remove: list[int]) -> None:
+    def prune_layer_out(self, indices_to_remove: np.ndarray | list[int]) -> None:
         """
         Shrink ``self.layer`` by dropping the given output rows of its weight
         (and the matching bias entries, if any).
 
         Parameters
         ----------
-        indices_to_remove: list[int]
-            Row indices in ``self.layer.weight`` to drop. Assumed already
-            de-duplicated, sorted, and in-range by the caller.
+        indices_to_remove: np.ndarray | list[int]
+            Row indices in ``self.layer.weight`` to drop.
         """
-        keep = [i for i in range(self.out_features) if i not in set(indices_to_remove)]
-        keep_idx = torch.tensor(keep, device=self.device, dtype=torch.long)
+        if isinstance(indices_to_remove, list):
+            indices_to_remove = np.array(indices_to_remove)
+        elif not isinstance(indices_to_remove, np.ndarray):
+            raise TypeError("indices_to_remove must be a numpy.ndarray or a list")
+        if not np.issubdtype(indices_to_remove.dtype, np.integer):
+            raise TypeError("indices_to_remove must contain integers")
+
+        keep = np.setdiff1d(np.arange(self.out_features), indices_to_remove)
+        keep_idx = torch.from_numpy(keep).to(device=self.device, dtype=torch.long)
+
+        weight_requires_grad = self.layer.weight.requires_grad
+        bias_requires_grad = self.layer.bias.requires_grad if self.layer.bias is not None else False
 
         new_layer = torch.nn.Linear(
             in_features=self.in_features,
@@ -1162,9 +1187,15 @@ class LinearGrowingModule(GrowingModule):
             bias=self.use_bias,
             device=self.device,
         )
-        new_layer.weight.data = self.layer.weight.index_select(0, keep_idx).clone()
+        new_layer.weight = torch.nn.Parameter(
+            self.layer.weight.index_select(0, keep_idx).clone(),
+            requires_grad=weight_requires_grad
+        )
         if self.use_bias:
-            new_layer.bias.data = self.layer.bias.data.index_select(0, keep_idx).clone()
+            new_layer.bias = torch.nn.Parameter(
+                self.layer.bias.index_select(0, keep_idx).clone(),
+                requires_grad=bias_requires_grad
+            )
 
         self.layer = new_layer
 

--- a/src/gromo/modules/linear_growing_module.py
+++ b/src/gromo/modules/linear_growing_module.py
@@ -1125,11 +1125,11 @@ class LinearGrowingModule(GrowingModule):
         )
         new_layer.weight.data = self.layer.weight.index_select(1, keep_idx).clone()
         if self.use_bias:
-            new_layer.bias.data = self.layer.bias.data.clone()  #bias unchanged
+            new_layer.bias.data = self.layer.bias.data.clone()  # bias unchanged
 
         self.layer = new_layer
 
-        use_bias = int(self.use_bias) # convert bool to int for the shape of S and M
+        use_bias = int(self.use_bias)  # convert bool to int for the shape of S and M
         self._tensor_s = TensorStatistic(
             (self.in_features + use_bias, self.in_features + use_bias),
             update_function=self.compute_s_update,
@@ -1140,8 +1140,6 @@ class LinearGrowingModule(GrowingModule):
             update_function=self.compute_m_update,
             name=self.tensor_m.name,
         )
-
-
 
     @torch.no_grad()
     def prune_layer_out(self, indices_to_remove: list[int]) -> None:
@@ -1175,4 +1173,3 @@ class LinearGrowingModule(GrowingModule):
             update_function=self.compute_m_update,
             name=self.tensor_m.name,
         )
-

--- a/src/gromo/modules/linear_growing_module.py
+++ b/src/gromo/modules/linear_growing_module.py
@@ -1125,7 +1125,9 @@ class LinearGrowingModule(GrowingModule):
         keep_idx = torch.from_numpy(keep).to(device=self.device, dtype=torch.long)
 
         weight_requires_grad = self.layer.weight.requires_grad
-        bias_requires_grad = self.layer.bias.requires_grad if self.layer.bias is not None else False
+        bias_requires_grad = (
+            self.layer.bias.requires_grad if self.layer.bias is not None else False
+        )
 
         new_layer = torch.nn.Linear(
             in_features=len(keep),
@@ -1135,12 +1137,11 @@ class LinearGrowingModule(GrowingModule):
         )
         new_layer.weight = torch.nn.Parameter(
             self.layer.weight.index_select(1, keep_idx).clone(),
-            requires_grad=weight_requires_grad
+            requires_grad=weight_requires_grad,
         )
         if self.use_bias:
             new_layer.bias = torch.nn.Parameter(
-                self.layer.bias.clone(),
-                requires_grad=bias_requires_grad
+                self.layer.bias.clone(), requires_grad=bias_requires_grad
             )
 
         self.layer = new_layer
@@ -1179,7 +1180,9 @@ class LinearGrowingModule(GrowingModule):
         keep_idx = torch.from_numpy(keep).to(device=self.device, dtype=torch.long)
 
         weight_requires_grad = self.layer.weight.requires_grad
-        bias_requires_grad = self.layer.bias.requires_grad if self.layer.bias is not None else False
+        bias_requires_grad = (
+            self.layer.bias.requires_grad if self.layer.bias is not None else False
+        )
 
         new_layer = torch.nn.Linear(
             in_features=self.in_features,
@@ -1189,12 +1192,12 @@ class LinearGrowingModule(GrowingModule):
         )
         new_layer.weight = torch.nn.Parameter(
             self.layer.weight.index_select(0, keep_idx).clone(),
-            requires_grad=weight_requires_grad
+            requires_grad=weight_requires_grad,
         )
         if self.use_bias:
             new_layer.bias = torch.nn.Parameter(
                 self.layer.bias.index_select(0, keep_idx).clone(),
-                requires_grad=bias_requires_grad
+                requires_grad=bias_requires_grad,
             )
 
         self.layer = new_layer

--- a/src/gromo/modules/linear_growing_module.py
+++ b/src/gromo/modules/linear_growing_module.py
@@ -1100,3 +1100,79 @@ class LinearGrowingModule(GrowingModule):
         self.extended_output_layer = torch.nn.Linear(
             self.in_features, extension_size, bias=self.use_bias, device=self.device
         )
+
+    @torch.no_grad()
+    def prune_layer_in(self, indices_to_remove: list[int]) -> None:
+        """
+        Shrink ``self.layer`` by dropping the given input columns of its weight.
+
+        Bias is unchanged (bias dim = out_features).
+
+        Parameters
+        ----------
+        indices_to_remove: list[int]
+            Column indices in ``self.layer.weight`` to drop. Assumed already
+            de-duplicated, sorted, and in-range by the caller.
+        """
+        keep = [i for i in range(self.in_features) if i not in set(indices_to_remove)]
+        keep_idx = torch.tensor(keep, device=self.device, dtype=torch.long)
+
+        new_layer = torch.nn.Linear(
+            in_features=len(keep),
+            out_features=self.out_features,
+            bias=self.use_bias,
+            device=self.device,
+        )
+        new_layer.weight.data = self.layer.weight.index_select(1, keep_idx).clone()
+        if self.use_bias:
+            new_layer.bias.data = self.layer.bias.data.clone()  #bias unchanged
+
+        self.layer = new_layer
+
+        use_bias = int(self.use_bias) # convert bool to int for the shape of S and M
+        self._tensor_s = TensorStatistic(
+            (self.in_features + use_bias, self.in_features + use_bias),
+            update_function=self.compute_s_update,
+            name=self.tensor_s.name,
+        )
+        self.tensor_m = TensorStatistic(
+            (self.in_features + use_bias, self.out_features),
+            update_function=self.compute_m_update,
+            name=self.tensor_m.name,
+        )
+
+
+
+    @torch.no_grad()
+    def prune_layer_out(self, indices_to_remove: list[int]) -> None:
+        """
+        Shrink ``self.layer`` by dropping the given output rows of its weight
+        (and the matching bias entries, if any).
+
+        Parameters
+        ----------
+        indices_to_remove: list[int]
+            Row indices in ``self.layer.weight`` to drop. Assumed already
+            de-duplicated, sorted, and in-range by the caller.
+        """
+        keep = [i for i in range(self.out_features) if i not in set(indices_to_remove)]
+        keep_idx = torch.tensor(keep, device=self.device, dtype=torch.long)
+
+        new_layer = torch.nn.Linear(
+            in_features=self.in_features,
+            out_features=len(keep),
+            bias=self.use_bias,
+            device=self.device,
+        )
+        new_layer.weight.data = self.layer.weight.index_select(0, keep_idx).clone()
+        if self.use_bias:
+            new_layer.bias.data = self.layer.bias.data.index_select(0, keep_idx).clone()
+
+        self.layer = new_layer
+
+        self.tensor_m = TensorStatistic(
+            (self.in_features + int(self.use_bias), self.out_features),
+            update_function=self.compute_m_update,
+            name=self.tensor_m.name,
+        )
+

--- a/src/gromo/modules/linear_growing_module.py
+++ b/src/gromo/modules/linear_growing_module.py
@@ -1111,8 +1111,13 @@ class LinearGrowingModule(GrowingModule):
 
         Parameters
         ----------
-        indices_to_remove: np.ndarray | list[int]
+        indices_to_remove : np.ndarray | list[int]
             Column indices in ``self.layer.weight`` to drop.
+
+        Raises
+        ------
+        TypeError
+            If indices_to_remove is not a numpy.ndarray or a list, or does not contain integers.
         """
         if isinstance(indices_to_remove, list):
             indices_to_remove = np.array(indices_to_remove)
@@ -1166,8 +1171,13 @@ class LinearGrowingModule(GrowingModule):
 
         Parameters
         ----------
-        indices_to_remove: np.ndarray | list[int]
+        indices_to_remove : np.ndarray | list[int]
             Row indices in ``self.layer.weight`` to drop.
+
+        Raises
+        ------
+        TypeError
+            If indices_to_remove is not a numpy.ndarray or a list, or does not contain integers.
         """
         if isinstance(indices_to_remove, list):
             indices_to_remove = np.array(indices_to_remove)

--- a/src/gromo/utils/training_utils.py
+++ b/src/gromo/utils/training_utils.py
@@ -84,7 +84,7 @@ def enumerate_dataloader(
     dataloader_seed: int | None = None,
     batch_limit: int | None = None,
     epochs: float | None = None,
-) -> Generator[tuple[int, Any]]:
+) -> Generator[tuple[int, Any], None, None]:
     """
     A generator that yields batches from a dataloader with an optional batch limit.
 
@@ -105,7 +105,7 @@ def enumerate_dataloader(
 
     Yields
     ------
-    Generator[tuple[int, Any]]
+    tuple[int, Any]
         A generator yielding tuples of (batch_index, batch_data).
 
     Raises

--- a/tests/test_conv2d_growing_module.py
+++ b/tests/test_conv2d_growing_module.py
@@ -677,6 +677,88 @@ class TestConv2dGrowingModule(TestConv2dGrowingModuleBase):
 
         self.demo_couple = {b: self.create_demo_layers(b) for b in (True, False)}
 
+    # ------------------------------------------------------------------ #
+    # Pruning
+    # ------------------------------------------------------------------ #
+    @unittest_parametrize(({"bias": True}, {"bias": False}))
+    def test_prune_layer_out(self, bias):
+        """prune_layer_out drops the given output channels (and matching bias)."""
+        torch.manual_seed(0)
+        layer = self._tested_class(
+            in_channels=2, out_channels=5, kernel_size=(3, 3), padding=1,
+            use_bias=bias, device=global_device(),
+        )
+        original = deepcopy(layer)
+        indices = [1, 3]
+        keep = torch.tensor([0, 2, 4], device=global_device())
+
+        layer.prune_layer_out(indices)
+
+        self.assertEqual(layer.in_channels, original.in_channels)
+        self.assertEqual(layer.out_channels, original.out_channels - len(indices))
+        self.assertAllClose(layer.layer.weight, original.layer.weight.index_select(0, keep))
+        if bias:
+            self.assertAllClose(layer.layer.bias, original.layer.bias.index_select(0, keep))
+        # forward equivalence on the channel axis: pruned(x) == original(x)[:, keep]
+        x = torch.randn(4, 2, 8, 8, device=global_device())
+        self.assertAllClose(layer(x), original(x).index_select(1, keep))
+        # recreated tensor_m shape: (in_channels * k0 * k1 + bias, out_channels)
+        k0, k1 = layer.layer.kernel_size
+        in_dim = layer.in_channels * k0 * k1 + int(bias)
+        self.assertEqual(layer.tensor_m._shape, (in_dim, layer.out_channels))
+
+    @unittest_parametrize(({"bias": True}, {"bias": False}))
+    def test_prune_layer_in(self, bias):
+        """prune_layer_in drops the given input channels; recreates tensor_s and tensor_m."""
+        torch.manual_seed(0)
+        layer = self._tested_class(
+            in_channels=4, out_channels=3, kernel_size=(3, 3), padding=1,
+            use_bias=bias, device=global_device(),
+        )
+        original = deepcopy(layer)
+        indices = [1, 3]
+        keep = torch.tensor([0, 2], device=global_device())
+
+        layer.prune_layer_in(indices)
+
+        self.assertEqual(layer.in_channels, original.in_channels - len(indices))
+        self.assertEqual(layer.out_channels, original.out_channels)
+        self.assertAllClose(layer.layer.weight, original.layer.weight.index_select(1, keep))
+        if bias:
+            self.assertAllClose(layer.layer.bias, original.layer.bias)
+        # forward equivalence: zeroing the removed input channels of the original
+        # equals feeding only the kept channels to the pruned layer
+        x = torch.randn(4, 4, 8, 8, device=global_device())
+        x_masked = x.clone()
+        x_masked[:, indices] = 0.0
+        self.assertAllClose(layer(x.index_select(1, keep)), original(x_masked))
+        # recreated stats shapes: in_dim = in_channels * k0 * k1 + bias
+        k0, k1 = layer.layer.kernel_size
+        in_dim = layer.in_channels * k0 * k1 + int(bias)
+        self.assertEqual(layer.tensor_s._shape, (in_dim, in_dim))
+        self.assertEqual(layer.tensor_m._shape, (in_dim, layer.out_channels))
+
+    def test_prune_layer_in_statistics_regather(self):
+        """After prune_layer_in, the re-created tensor_s can accumulate a fresh gather."""
+        torch.manual_seed(0)
+        layer = self._tested_class(
+            in_channels=4, out_channels=3, kernel_size=(3, 3), padding=1,
+            use_bias=True, device=global_device(),
+        )
+        layer.prune_layer_in([1, 3])
+
+        # gather statistics on the pruned layer (mirrors test_tensor_s_update_*)
+        layer.store_input = True
+        layer.tensor_s.init()
+        x = torch.randn(5, layer.in_channels, 8, 8, device=global_device())
+        layer(x)
+        layer.tensor_s.update()  # would trip the size assert if _shape were wrong
+
+        k0, k1 = layer.layer.kernel_size
+        in_dim = layer.in_channels * k0 * k1 + 1  # +1 for bias
+        self.assertEqual(layer.tensor_s.samples, x.size(0))
+        self.assertShapeEqual(layer.tensor_s(), (in_dim, in_dim))
+
     def test_get_fan_in_from_layer(self):
         """Test get_fan_in_from_layer method."""
         layer = self.demo_couple[True][0]

--- a/tests/test_conv2d_growing_module.py
+++ b/tests/test_conv2d_growing_module.py
@@ -2568,5 +2568,51 @@ class TestNeuronCountingConv2d(TestConv2dGrowingModuleBase):
         self.assertEqual(layer.number_of_neurons_to_add(number_of_growth_steps=2), 5)
 
 
+class TestConv2dPruningValidation(TorchTestCase):
+    def test_prune_layer_validation_and_errors(self):
+        layer = Conv2dGrowingModule(
+            in_channels=4,
+            out_channels=3,
+            kernel_size=(3, 3),
+            padding=1,
+            device=global_device(),
+        )
+
+        # list input validation (converting to numpy array)
+        layer.prune_layer_in([1, 3])
+        self.assertEqual(layer.in_channels, 2)
+
+        # invalid type -> TypeError
+        with self.assertRaises(TypeError):
+            layer.prune_layer_in("invalid")
+        with self.assertRaises(TypeError):
+            layer.prune_layer_out("invalid")
+
+        # non-integer type -> TypeError
+        with self.assertRaises(TypeError):
+            layer.prune_layer_in(np.array([1.0, 2.0]))
+        with self.assertRaises(TypeError):
+            layer.prune_layer_out(np.array([1.0, 2.0]))
+
+        # groups != 1 -> NotImplementedError
+        grouped_layer = Conv2dGrowingModule(
+            in_channels=4,
+            out_channels=4,
+            kernel_size=(3, 3),
+            device=global_device(),
+        )
+        grouped_layer.layer = torch.nn.Conv2d(
+            in_channels=4,
+            out_channels=4,
+            kernel_size=(3, 3),
+            groups=2,
+            device=global_device(),
+        )
+        with self.assertRaises(NotImplementedError):
+            grouped_layer.prune_layer_in(np.array([0]))
+        with self.assertRaises(NotImplementedError):
+            grouped_layer.prune_layer_out(np.array([0]))
+
+
 if __name__ == "__main__":
     main()

--- a/tests/test_conv2d_growing_module.py
+++ b/tests/test_conv2d_growing_module.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 from unittest import main, mock
 
 import numpy as np
-
 import torch
 
 from gromo.modules.conv2d_growing_module import (
@@ -687,8 +686,12 @@ class TestConv2dGrowingModule(TestConv2dGrowingModuleBase):
         """prune_layer_out drops the given output channels (and matching bias)."""
         torch.manual_seed(0)
         layer = self._tested_class(
-            in_channels=2, out_channels=5, kernel_size=(3, 3), padding=1,
-            use_bias=bias, device=global_device(),
+            in_channels=2,
+            out_channels=5,
+            kernel_size=(3, 3),
+            padding=1,
+            use_bias=bias,
+            device=global_device(),
         )
         original = deepcopy(layer)
         indices = np.array([1, 3])
@@ -698,11 +701,19 @@ class TestConv2dGrowingModule(TestConv2dGrowingModuleBase):
 
         self.assertEqual(layer.in_channels, original.in_channels)
         self.assertEqual(layer.out_channels, original.out_channels - len(indices))
-        self.assertAllClose(layer.layer.weight, original.layer.weight.index_select(0, keep))
-        self.assertEqual(layer.layer.weight.requires_grad, original.layer.weight.requires_grad)
+        self.assertAllClose(
+            layer.layer.weight, original.layer.weight.index_select(0, keep)
+        )
+        self.assertEqual(
+            layer.layer.weight.requires_grad, original.layer.weight.requires_grad
+        )
         if bias:
-            self.assertAllClose(layer.layer.bias, original.layer.bias.index_select(0, keep))
-            self.assertEqual(layer.layer.bias.requires_grad, original.layer.bias.requires_grad)
+            self.assertAllClose(
+                layer.layer.bias, original.layer.bias.index_select(0, keep)
+            )
+            self.assertEqual(
+                layer.layer.bias.requires_grad, original.layer.bias.requires_grad
+            )
         # forward equivalence on the channel axis: pruned(x) == original(x)[:, keep]
         x = torch.randn(4, 2, 8, 8, device=global_device())
         self.assertAllClose(layer(x), original(x).index_select(1, keep))
@@ -716,8 +727,12 @@ class TestConv2dGrowingModule(TestConv2dGrowingModuleBase):
         """prune_layer_in drops the given input channels; recreates tensor_s and tensor_m."""
         torch.manual_seed(0)
         layer = self._tested_class(
-            in_channels=4, out_channels=3, kernel_size=(3, 3), padding=1,
-            use_bias=bias, device=global_device(),
+            in_channels=4,
+            out_channels=3,
+            kernel_size=(3, 3),
+            padding=1,
+            use_bias=bias,
+            device=global_device(),
         )
         original = deepcopy(layer)
         indices = np.array([1, 3])
@@ -727,11 +742,17 @@ class TestConv2dGrowingModule(TestConv2dGrowingModuleBase):
 
         self.assertEqual(layer.in_channels, original.in_channels - len(indices))
         self.assertEqual(layer.out_channels, original.out_channels)
-        self.assertAllClose(layer.layer.weight, original.layer.weight.index_select(1, keep))
-        self.assertEqual(layer.layer.weight.requires_grad, original.layer.weight.requires_grad)
+        self.assertAllClose(
+            layer.layer.weight, original.layer.weight.index_select(1, keep)
+        )
+        self.assertEqual(
+            layer.layer.weight.requires_grad, original.layer.weight.requires_grad
+        )
         if bias:
             self.assertAllClose(layer.layer.bias, original.layer.bias)
-            self.assertEqual(layer.layer.bias.requires_grad, original.layer.bias.requires_grad)
+            self.assertEqual(
+                layer.layer.bias.requires_grad, original.layer.bias.requires_grad
+            )
         # forward equivalence: zeroing the removed input channels of the original
         # equals feeding only the kept channels to the pruned layer
         x = torch.randn(4, 4, 8, 8, device=global_device())
@@ -748,8 +769,12 @@ class TestConv2dGrowingModule(TestConv2dGrowingModuleBase):
         """After prune_layer_in, the re-created tensor_s can accumulate a fresh gather."""
         torch.manual_seed(0)
         layer = self._tested_class(
-            in_channels=4, out_channels=3, kernel_size=(3, 3), padding=1,
-            use_bias=True, device=global_device(),
+            in_channels=4,
+            out_channels=3,
+            kernel_size=(3, 3),
+            padding=1,
+            use_bias=True,
+            device=global_device(),
         )
         layer.prune_layer_in(np.array([1, 3]))
 
@@ -768,6 +793,7 @@ class TestConv2dGrowingModule(TestConv2dGrowingModuleBase):
     def test_prune_neurons_in_with_growingbatchnorm2d(self):
         """The previous module's GrowingBatchNorm2d post-layer is pruned alongside the hidden dim."""
         from gromo.modules.growing_normalisation import GrowingBatchNorm2d
+
         hidden = 4
         first, second = self.create_demo_layers(bias=True, hidden_channels=hidden)
         bn = GrowingBatchNorm2d(hidden, device=global_device())

--- a/tests/test_conv2d_growing_module.py
+++ b/tests/test_conv2d_growing_module.py
@@ -4,6 +4,8 @@ import warnings
 from copy import deepcopy
 from unittest import main, mock
 
+import numpy as np
+
 import torch
 
 from gromo.modules.conv2d_growing_module import (
@@ -689,7 +691,7 @@ class TestConv2dGrowingModule(TestConv2dGrowingModuleBase):
             use_bias=bias, device=global_device(),
         )
         original = deepcopy(layer)
-        indices = [1, 3]
+        indices = np.array([1, 3])
         keep = torch.tensor([0, 2, 4], device=global_device())
 
         layer.prune_layer_out(indices)
@@ -697,8 +699,10 @@ class TestConv2dGrowingModule(TestConv2dGrowingModuleBase):
         self.assertEqual(layer.in_channels, original.in_channels)
         self.assertEqual(layer.out_channels, original.out_channels - len(indices))
         self.assertAllClose(layer.layer.weight, original.layer.weight.index_select(0, keep))
+        self.assertEqual(layer.layer.weight.requires_grad, original.layer.weight.requires_grad)
         if bias:
             self.assertAllClose(layer.layer.bias, original.layer.bias.index_select(0, keep))
+            self.assertEqual(layer.layer.bias.requires_grad, original.layer.bias.requires_grad)
         # forward equivalence on the channel axis: pruned(x) == original(x)[:, keep]
         x = torch.randn(4, 2, 8, 8, device=global_device())
         self.assertAllClose(layer(x), original(x).index_select(1, keep))
@@ -716,7 +720,7 @@ class TestConv2dGrowingModule(TestConv2dGrowingModuleBase):
             use_bias=bias, device=global_device(),
         )
         original = deepcopy(layer)
-        indices = [1, 3]
+        indices = np.array([1, 3])
         keep = torch.tensor([0, 2], device=global_device())
 
         layer.prune_layer_in(indices)
@@ -724,13 +728,15 @@ class TestConv2dGrowingModule(TestConv2dGrowingModuleBase):
         self.assertEqual(layer.in_channels, original.in_channels - len(indices))
         self.assertEqual(layer.out_channels, original.out_channels)
         self.assertAllClose(layer.layer.weight, original.layer.weight.index_select(1, keep))
+        self.assertEqual(layer.layer.weight.requires_grad, original.layer.weight.requires_grad)
         if bias:
             self.assertAllClose(layer.layer.bias, original.layer.bias)
+            self.assertEqual(layer.layer.bias.requires_grad, original.layer.bias.requires_grad)
         # forward equivalence: zeroing the removed input channels of the original
         # equals feeding only the kept channels to the pruned layer
         x = torch.randn(4, 4, 8, 8, device=global_device())
         x_masked = x.clone()
-        x_masked[:, indices] = 0.0
+        x_masked[:, [1, 3]] = 0.0
         self.assertAllClose(layer(x.index_select(1, keep)), original(x_masked))
         # recreated stats shapes: in_dim = in_channels * k0 * k1 + bias
         k0, k1 = layer.layer.kernel_size
@@ -745,7 +751,7 @@ class TestConv2dGrowingModule(TestConv2dGrowingModuleBase):
             in_channels=4, out_channels=3, kernel_size=(3, 3), padding=1,
             use_bias=True, device=global_device(),
         )
-        layer.prune_layer_in([1, 3])
+        layer.prune_layer_in(np.array([1, 3]))
 
         # gather statistics on the pruned layer (mirrors test_tensor_s_update_*)
         layer.store_input = True
@@ -758,6 +764,43 @@ class TestConv2dGrowingModule(TestConv2dGrowingModuleBase):
         in_dim = layer.in_channels * k0 * k1 + 1  # +1 for bias
         self.assertEqual(layer.tensor_s.samples, x.size(0))
         self.assertShapeEqual(layer.tensor_s(), (in_dim, in_dim))
+
+    def test_prune_neurons_in_with_growingbatchnorm2d(self):
+        """The previous module's GrowingBatchNorm2d post-layer is pruned alongside the hidden dim."""
+        from gromo.modules.growing_normalisation import GrowingBatchNorm2d
+        hidden = 4
+        first, second = self.create_demo_layers(bias=True, hidden_channels=hidden)
+        bn = GrowingBatchNorm2d(hidden, device=global_device())
+        first.post_layer_function = bn
+
+        with torch.no_grad():
+            bn.weight.copy_(torch.randn(hidden, device=global_device()))
+            bn.bias.copy_(torch.randn(hidden, device=global_device()))
+        bn.running_mean.copy_(torch.randn(hidden, device=global_device()))
+        bn.running_var.copy_(torch.abs(torch.randn(hidden, device=global_device())) + 0.1)
+
+        original_weight = bn.weight.detach().clone()
+        original_bias = bn.bias.detach().clone()
+        original_running_mean = bn.running_mean.clone()
+        original_running_var = bn.running_var.clone()
+
+        indices = np.array([0, 2])
+        keep = torch.tensor([1, 3], device=global_device())
+        new_hidden = hidden - len(indices)
+
+        second.prune_neurons_in(indices)
+
+        self.assertEqual(bn.num_features, new_hidden)
+        self.assertAllClose(bn.weight, original_weight.index_select(0, keep))
+        self.assertAllClose(bn.bias, original_bias.index_select(0, keep))
+        self.assertAllClose(bn.running_mean, original_running_mean.index_select(0, keep))
+        self.assertAllClose(bn.running_var, original_running_var.index_select(0, keep))
+
+        # chain forward works with the pruned feature count
+        first.eval()
+        x = torch.randn(4, first.in_channels, 10, 10, device=global_device())
+        y = second(first(x))
+        self.assertShapeEqual(y, (4, second.out_channels, 6, 6))
 
     def test_get_fan_in_from_layer(self):
         """Test get_fan_in_from_layer method."""

--- a/tests/test_growing_module.py
+++ b/tests/test_growing_module.py
@@ -1518,6 +1518,83 @@ class TestScalingMethods(TorchTestCase):
         self.assertIs(returned_layer, layer, "scale_layer should return the same layer")
 
 
+class TestGrowingModulePruningValidation(TorchTestCase):
+    def test_prune_neurons_in_validation(self):
+        import numpy as np
+
+        first = LinearGrowingModule(in_features=5, out_features=4, device=global_device())
+        second = LinearGrowingModule(
+            in_features=4, out_features=3, previous_module=first, device=global_device()
+        )
+
+        # list conversion
+        second.prune_neurons_in([1, 3])
+        self.assertEqual(second.in_features, 2)
+
+        # Recreate layers
+        first = LinearGrowingModule(in_features=5, out_features=4, device=global_device())
+        second = LinearGrowingModule(
+            in_features=4, out_features=3, previous_module=first, device=global_device()
+        )
+
+        # invalid type -> TypeError
+        with self.assertRaises(TypeError):
+            second.prune_neurons_in("invalid")
+
+        # non-integer type -> TypeError
+        with self.assertRaises(TypeError):
+            second.prune_neurons_in(np.array([1.0, 2.0]))
+
+        # empty index -> no-op
+        second.prune_neurons_in(np.array([], dtype=np.int64))
+        self.assertEqual(second.in_features, 4)
+
+        # previous module is not GrowingModule -> TypeError
+        third = LinearGrowingModule(
+            in_features=4, out_features=3, previous_module=None, device=global_device()
+        )
+        with self.assertRaises(TypeError):
+            third.prune_neurons_in(np.array([0]))
+
+        # out of range -> IndexError
+        with self.assertRaises(IndexError):
+            second.prune_neurons_in(np.array([4]))
+        with self.assertRaises(IndexError):
+            second.prune_neurons_in(np.array([-1]))
+
+        # prune all features -> ValueError
+        with self.assertRaises(ValueError):
+            second.prune_neurons_in(np.array([0, 1, 2, 3]))
+
+    def test_prune_post_layer_function_none(self):
+        import numpy as np
+
+        # post_layer_function is None
+        first = LinearGrowingModule(in_features=5, out_features=4, device=global_device())
+        first.post_layer_function = None
+        second = LinearGrowingModule(
+            in_features=4, out_features=3, previous_module=first, device=global_device()
+        )
+
+        # should run successfully without error
+        second.prune_neurons_in(np.array([0]))
+        self.assertEqual(second.in_features, 3)
+
+    def test_prune_post_layer_function_unsupported_module(self):
+        import numpy as np
+
+        # post_layer_function is nn.Linear, which has parameters but no prune method
+        first = LinearGrowingModule(in_features=5, out_features=4, device=global_device())
+        first.post_layer_function = torch.nn.Linear(4, 4, device=global_device())
+        second = LinearGrowingModule(
+            in_features=4, out_features=3, previous_module=first, device=global_device()
+        )
+
+        with self.assertRaises(TypeError) as ctx:
+            second.prune_neurons_in(np.array([0]))
+        self.assertIn("does not support pruning", str(ctx.exception))
+
+
 if __name__ == "__main__":
     from unittest import main
 

--- a/tests/test_growing_normalisation.py
+++ b/tests/test_growing_normalisation.py
@@ -1120,5 +1120,241 @@ class TestGrowingGroupNorm(unittest.TestCase):
         torch.testing.assert_close(processed_x_ext, x_ext)
 
 
+class TestGrowingNormalisationPruning(unittest.TestCase):
+    def setUp(self):
+        self.device = torch.device("cpu")
+
+    def test_batch_norm_pruning_validation_and_edge_cases(self):
+        import numpy as np
+
+        bn = GrowingBatchNorm1d(num_features=8, device=self.device)
+
+        # indices_to_remove is list
+        bn.prune([1, 3])
+        self.assertEqual(bn.num_features, 6)
+
+        # invalid type -> TypeError
+        with self.assertRaises(TypeError):
+            bn.prune("invalid")
+
+        # non-integer dtype -> TypeError
+        with self.assertRaises(TypeError):
+            bn.prune(np.array([1.0, 2.0]))
+
+        # empty index -> no-op
+        bn.prune(np.array([], dtype=np.int64))
+        self.assertEqual(bn.num_features, 6)
+
+        # out-of-bounds -> IndexError
+        with self.assertRaises(IndexError):
+            bn.prune([6])
+        with self.assertRaises(IndexError):
+            bn.prune([-1])
+
+        # pruning all features -> ValueError
+        with self.assertRaises(ValueError):
+            bn.prune([0, 1, 2, 3, 4, 5])
+
+    def test_batch_norm_prune_affine_and_running_stats(self):
+        bn_no_affine = GrowingBatchNorm1d(
+            num_features=8, affine=False, device=self.device
+        )
+        self.assertIsNone(bn_no_affine.weight)
+        bn_no_affine.prune([0, 2])
+        self.assertEqual(bn_no_affine.num_features, 6)
+        self.assertIsNone(bn_no_affine.weight)
+
+        bn_no_stats = GrowingBatchNorm1d(
+            num_features=8, track_running_stats=False, device=self.device
+        )
+        self.assertIsNone(bn_no_stats.running_mean)
+        bn_no_stats.prune([0, 2])
+        self.assertEqual(bn_no_stats.num_features, 6)
+        self.assertIsNone(bn_no_stats.running_mean)
+
+        # test bias is None with affine=True
+        bn_bias_none = GrowingBatchNorm1d(num_features=8, affine=True, device=self.device)
+        bn_bias_none.bias = None
+        bn_bias_none.prune([0, 2])
+        self.assertEqual(bn_bias_none.num_features, 6)
+        self.assertIsNone(bn_bias_none.bias)
+
+        # test running stats are None with track_running_stats=True
+        bn_stats_none = GrowingBatchNorm1d(
+            num_features=8, track_running_stats=True, device=self.device
+        )
+        bn_stats_none.running_mean = None
+        bn_stats_none.running_var = None
+        bn_stats_none.prune([0, 2])
+        self.assertEqual(bn_stats_none.num_features, 6)
+        self.assertIsNone(bn_stats_none.running_mean)
+        self.assertIsNone(bn_stats_none.running_var)
+
+    def test_layer_norm_pruning_validation_and_edge_cases(self):
+        import numpy as np
+
+        ln = GrowingLayerNorm(8, device=self.device)
+
+        # indices_to_remove is list
+        ln.prune([1, 3])
+        self.assertEqual(ln.normalized_shape, (6,))
+
+        # invalid type -> TypeError
+        with self.assertRaises(TypeError):
+            ln.prune("invalid")
+
+        # non-integer dtype -> TypeError
+        with self.assertRaises(TypeError):
+            ln.prune(np.array([1.0, 2.0]))
+
+        # empty index -> no-op
+        ln.prune(np.array([], dtype=np.int64))
+        self.assertEqual(ln.normalized_shape, (6,))
+
+        # out-of-bounds -> IndexError
+        with self.assertRaises(IndexError):
+            ln.prune([6])
+        with self.assertRaises(IndexError):
+            ln.prune([-1])
+
+        # pruning all features -> ValueError
+        with self.assertRaises(ValueError):
+            ln.prune([0, 1, 2, 3, 4, 5])
+
+    def test_layer_norm_prune_elementwise_affine_false(self):
+        ln = GrowingLayerNorm(8, elementwise_affine=False, device=self.device)
+        self.assertIsNone(ln.weight)
+        ln.prune([0, 2])
+        self.assertEqual(ln.normalized_shape, (6,))
+        self.assertIsNone(ln.weight)
+
+        # bias is None with elementwise_affine=True
+        ln_bias_none = GrowingLayerNorm(8, elementwise_affine=True, device=self.device)
+        ln_bias_none.bias = None
+        ln_bias_none.prune([0, 2])
+        self.assertEqual(ln_bias_none.normalized_shape, (6,))
+        self.assertIsNone(ln_bias_none.bias)
+
+    def test_group_norm_pruning_validation_and_edge_cases(self):
+        import numpy as np
+
+        gn = GrowingGroupNorm(num_groups=2, num_channels=8, device=self.device)
+
+        # indices_to_remove is list
+        gn.prune([1, 3])
+        self.assertEqual(gn.num_channels, 6)
+
+        # invalid type -> TypeError
+        with self.assertRaises(TypeError):
+            gn.prune("invalid")
+
+        # non-integer dtype -> TypeError
+        with self.assertRaises(TypeError):
+            gn.prune(np.array([1.0, 2.0]))
+
+        # empty index -> no-op
+        gn.prune(np.array([], dtype=np.int64))
+        self.assertEqual(gn.num_channels, 6)
+
+        # out-of-bounds -> IndexError
+        with self.assertRaises(IndexError):
+            gn.prune([6])
+        with self.assertRaises(IndexError):
+            gn.prune([-1])
+
+        # pruning all features -> ValueError
+        with self.assertRaises(ValueError):
+            gn.prune([0, 1, 2, 3, 4, 5])
+
+        # num_channels not divisible by num_groups -> ValueError
+        with self.assertRaises(ValueError):
+            gn.prune([0])
+
+    def test_group_norm_prune_affine_false(self):
+        gn = GrowingGroupNorm(
+            num_groups=2, num_channels=8, affine=False, device=self.device
+        )
+        self.assertIsNone(gn.weight)
+        gn.prune([0, 2])
+        self.assertEqual(gn.num_channels, 6)
+        self.assertIsNone(gn.weight)
+
+        # bias is None with affine=True
+        gn_bias_none = GrowingGroupNorm(
+            num_groups=2, num_channels=8, affine=True, device=self.device
+        )
+        gn_bias_none.bias = None
+        gn_bias_none.prune([0, 2])
+        self.assertEqual(gn_bias_none.num_channels, 6)
+        self.assertIsNone(gn_bias_none.bias)
+
+    def test_extend_parameter_mismatches(self):
+        # BatchNorm
+        bn = GrowingBatchNorm1d(num_features=8, device=self.device)
+        with self.assertRaises(ValueError):
+            bn.grow(4, new_weights=torch.ones(2))
+
+        # test direct call to _extend_parameter to trigger shape mismatch check at line 156
+        with self.assertRaises(ValueError):
+            bn._extend_parameter(
+                param_name="weight",
+                additional_features=4,
+                new_values=torch.ones(2),
+                default_value_fn=torch.ones,
+                device=self.device,
+                as_parameter=True,
+            )
+
+        # Recreate to avoid corrupted state
+        bn2 = GrowingBatchNorm1d(num_features=8, device=self.device)
+        cpu_device = torch.device("cpu")
+        new_w = torch.ones(4, dtype=torch.float64, device=cpu_device)
+        bn2.grow(4, new_weights=new_w)
+        self.assertEqual(bn2.num_features, 12)
+        self.assertEqual(bn2.weight.dtype, torch.float32)
+
+        # LayerNorm
+        ln = GrowingLayerNorm(8, device=self.device)
+        with self.assertRaises(ValueError):
+            ln.grow(4, new_weights=torch.ones(2))
+
+        with self.assertRaises(ValueError):
+            ln._extend_parameter(
+                param_name="weight",
+                additional_first_dim=4,
+                new_values=torch.ones(2),
+                default_value_fn=torch.ones,
+                device=self.device,
+                as_parameter=True,
+            )
+
+        ln2 = GrowingLayerNorm(8, device=self.device)
+        new_w = torch.ones(4, dtype=torch.float64, device=cpu_device)
+        ln2.grow(4, new_weights=new_w)
+        self.assertEqual(ln2.normalized_shape, (12,))
+        self.assertEqual(ln2.weight.dtype, torch.float32)
+
+        # GroupNorm
+        gn = GrowingGroupNorm(num_groups=2, num_channels=8, device=self.device)
+        with self.assertRaises(ValueError):
+            gn.grow(4, new_weights=torch.ones(2))
+
+        with self.assertRaises(ValueError):
+            gn._extend_parameter(
+                param_name="weight",
+                additional_channels=4,
+                new_values=torch.ones(2),
+                default_value_fn=torch.ones,
+                device=self.device,
+                as_parameter=True,
+            )
+
+        gn2 = GrowingGroupNorm(num_groups=2, num_channels=8, device=self.device)
+        new_w = torch.ones(4, dtype=torch.float64, device=cpu_device)
+        gn2.grow(4, new_weights=new_w)
+        self.assertEqual(gn2.num_channels, 12)
+        self.assertEqual(gn2.weight.dtype, torch.float32)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_linear_growing_module.py
+++ b/tests/test_linear_growing_module.py
@@ -4,6 +4,8 @@ from copy import deepcopy
 from typing import Literal
 from unittest import mock
 
+import numpy as np
+
 import torch
 
 from gromo.modules.linear_growing_module import (
@@ -474,7 +476,7 @@ class TestLinearGrowingModule(TestLinearGrowingModuleBase):
         torch.manual_seed(self.config.RANDOM_SEED)
         layer = self.create_linear_layer(in_features=5, out_features=4, bias=bias)
         original = deepcopy(layer)
-        indices = [1, 3]
+        indices = np.array([1, 3])
         keep = torch.tensor([0, 2], device=global_device())
 
         layer.prune_layer_out(indices)
@@ -482,8 +484,10 @@ class TestLinearGrowingModule(TestLinearGrowingModuleBase):
         self.assertEqual(layer.in_features, original.in_features)
         self.assertEqual(layer.out_features, original.out_features - len(indices))
         self.assertAllClose(layer.weight, original.weight.index_select(0, keep))
+        self.assertEqual(layer.weight.requires_grad, original.weight.requires_grad)
         if bias:
             self.assertAllClose(layer.bias, original.bias.index_select(0, keep))
+            self.assertEqual(layer.bias.requires_grad, original.bias.requires_grad)
         # forward equivalence: pruned(x) == original(x)[:, keep]
         x = torch.randn(self.n, 5, device=global_device())
         self.assertAllClose(layer(x), original(x).index_select(1, keep))
@@ -498,7 +502,7 @@ class TestLinearGrowingModule(TestLinearGrowingModuleBase):
         torch.manual_seed(self.config.RANDOM_SEED)
         layer = self.create_linear_layer(in_features=5, out_features=4, bias=bias)
         original = deepcopy(layer)
-        indices = [1, 3]
+        indices = np.array([1, 3])
         keep = torch.tensor([0, 2, 4], device=global_device())
 
         layer.prune_layer_in(indices)
@@ -506,13 +510,15 @@ class TestLinearGrowingModule(TestLinearGrowingModuleBase):
         self.assertEqual(layer.in_features, original.in_features - len(indices))
         self.assertEqual(layer.out_features, original.out_features)
         self.assertAllClose(layer.weight, original.weight.index_select(1, keep))
+        self.assertEqual(layer.weight.requires_grad, original.weight.requires_grad)
         if bias:
             self.assertAllClose(layer.bias, original.bias)
+            self.assertEqual(layer.bias.requires_grad, original.bias.requires_grad)
         # forward equivalence: zeroing the removed inputs of the original
         # equals feeding only the kept inputs to the pruned layer
         x = torch.randn(self.n, 5, device=global_device())
         x_masked = x.clone()
-        x_masked[:, indices] = 0.0
+        x_masked[:, [1, 3]] = 0.0
         self.assertAllClose(layer(x.index_select(1, keep)), original(x_masked))
         # recreated stats shapes
         use_bias = int(bias)
@@ -524,15 +530,15 @@ class TestLinearGrowingModule(TestLinearGrowingModuleBase):
             layer.tensor_m._shape, (layer.in_features + use_bias, layer.out_features)
         )
 
-    def test_prune_hidden_neurons_in(self):
+    def test_prune_neurons_in(self):
         """Pruning hidden neurons shrinks previous.out_features and self.in_features together."""
         first, second = self.create_demo_layers(bias=True, hidden_features=4)
         original_first_weight = first.weight.detach().clone()
         original_second_weight = second.weight.detach().clone()
-        indices = [0, 2]
+        indices = np.array([0, 2])
         keep = torch.tensor([1, 3], device=global_device())
 
-        second.prune_hidden_neurons_in(indices)
+        second.prune_neurons_in(indices)
 
         new_hidden = 4 - len(indices)
         self.assertEqual(first.out_features, new_hidden)
@@ -546,39 +552,33 @@ class TestLinearGrowingModule(TestLinearGrowingModuleBase):
         y = second(first(x))
         self.assertShapeEqual(y, (self.n, second.out_features))
 
-    def test_prune_hidden_neurons_in_with_batchnorm(self):
-        """The previous module's BatchNorm post-layer is pruned alongside the hidden dim."""
+    def test_prune_neurons_in_with_growingbatchnorm(self):
+        """The previous module's GrowingBatchNorm post-layer is pruned alongside the hidden dim."""
+        from gromo.modules.growing_normalisation import GrowingBatchNorm1d
         hidden = 4
         first, second = self.create_demo_layers(
             bias=True,
             hidden_features=hidden,
-            first_layer_post_layer=torch.nn.BatchNorm1d(hidden, device=global_device()),
+            first_layer_post_layer=GrowingBatchNorm1d(hidden, device=global_device()),
         )
         bn = first.post_layer_function
-        # give every channel a distinct value so we can check the right ones survive
+        # give every channel a distinct random value
         with torch.no_grad():
-            bn.weight.copy_(
-                torch.arange(hidden, dtype=torch.float32, device=global_device()) + 1.0
-            )
-            bn.bias.copy_(
-                torch.arange(hidden, dtype=torch.float32, device=global_device()) + 10.0
-            )
-        bn.running_mean = (
-            torch.arange(hidden, dtype=torch.float32, device=global_device()) + 20.0
-        )
-        bn.running_var = (
-            torch.arange(hidden, dtype=torch.float32, device=global_device()) + 30.0
-        )
+            bn.weight.copy_(torch.randn(hidden, device=global_device()))
+            bn.bias.copy_(torch.randn(hidden, device=global_device()))
+        bn.running_mean.copy_(torch.randn(hidden, device=global_device()))
+        bn.running_var.copy_(torch.abs(torch.randn(hidden, device=global_device())) + 0.1)
+
         original_weight = bn.weight.detach().clone()
         original_bias = bn.bias.detach().clone()
         original_running_mean = bn.running_mean.clone()
         original_running_var = bn.running_var.clone()
 
-        indices = [0, 2]
+        indices = np.array([0, 2])
         keep = torch.tensor([1, 3], device=global_device())
         new_hidden = hidden - len(indices)
 
-        second.prune_hidden_neurons_in(indices)
+        second.prune_neurons_in(indices)
 
         bn = first.post_layer_function
         self.assertEqual(bn.num_features, new_hidden)
@@ -592,30 +592,91 @@ class TestLinearGrowingModule(TestLinearGrowingModuleBase):
         y = second(first(x))
         self.assertShapeEqual(y, (self.n, second.out_features))
 
-    def test_prune_hidden_neurons_in_validation(self):
-        """Empty list is a no-op; bad indices and bad wiring raise (validation precedes mutation)."""
+    def test_prune_neurons_in_with_layernorm(self):
+        from gromo.modules.growing_normalisation import GrowingLayerNorm
+        hidden = 4
+        first, second = self.create_demo_layers(
+            bias=True,
+            hidden_features=hidden,
+            first_layer_post_layer=GrowingLayerNorm(hidden, device=global_device()),
+        )
+        ln = first.post_layer_function
+        with torch.no_grad():
+            ln.weight.copy_(torch.randn(hidden, device=global_device()))
+            ln.bias.copy_(torch.randn(hidden, device=global_device()))
+        original_weight = ln.weight.detach().clone()
+        original_bias = ln.bias.detach().clone()
+
+        indices = np.array([0, 2])
+        keep = torch.tensor([1, 3], device=global_device())
+        new_hidden = hidden - len(indices)
+
+        second.prune_neurons_in(indices)
+
+        ln = first.post_layer_function
+        self.assertEqual(ln.normalized_shape, (new_hidden,))
+        self.assertAllClose(ln.weight, original_weight.index_select(0, keep))
+        self.assertAllClose(ln.bias, original_bias.index_select(0, keep))
+        # chain forward works
+        x = torch.randn(self.n, first.in_features, device=global_device())
+        y = second(first(x))
+        self.assertShapeEqual(y, (self.n, second.out_features))
+
+    def test_prune_neurons_in_with_groupnorm(self):
+        from gromo.modules.growing_normalisation import GrowingGroupNorm
+        hidden = 4
+        first, second = self.create_demo_layers(
+            bias=True,
+            hidden_features=hidden,
+            first_layer_post_layer=GrowingGroupNorm(num_groups=2, num_channels=hidden, device=global_device()),
+        )
+        gn = first.post_layer_function
+        with torch.no_grad():
+            gn.weight.copy_(torch.randn(hidden, device=global_device()))
+            gn.bias.copy_(torch.randn(hidden, device=global_device()))
+        original_weight = gn.weight.detach().clone()
+        original_bias = gn.bias.detach().clone()
+
+        indices = np.array([0, 2])
+        keep = torch.tensor([1, 3], device=global_device())
+        new_hidden = hidden - len(indices)
+
+        second.prune_neurons_in(indices)
+
+        gn = first.post_layer_function
+        self.assertEqual(gn.num_channels, new_hidden)
+        self.assertEqual(gn.num_groups, 2)
+        self.assertAllClose(gn.weight, original_weight.index_select(0, keep))
+        self.assertAllClose(gn.bias, original_bias.index_select(0, keep))
+        # chain forward works
+        x = torch.randn(self.n, first.in_features, device=global_device())
+        y = second(first(x))
+        self.assertShapeEqual(y, (self.n, second.out_features))
+
+    def test_prune_neurons_in_validation(self):
+        """Empty array is a no-op; bad indices and bad wiring raise (validation precedes mutation)."""
         first, second = self.create_demo_layers(bias=True, hidden_features=4)
 
-        # empty list -> no-op
-        second.prune_hidden_neurons_in([])
+        # empty array -> no-op
+        second.prune_neurons_in(np.array([], dtype=np.int64))
         self.assertEqual(first.out_features, 4)
         self.assertEqual(second.in_features, 4)
 
         # out-of-range / negative index -> IndexError
         with self.assertRaises(IndexError):
-            second.prune_hidden_neurons_in([4])
+            second.prune_neurons_in(np.array([4]))
         with self.assertRaises(IndexError):
-            second.prune_hidden_neurons_in([-1])
+            second.prune_neurons_in(np.array([-1]))
 
         # pruning all hidden neurons -> ValueError
         with self.assertRaises(ValueError) as ctx:
-            second.prune_hidden_neurons_in([0, 1, 2, 3])
+            second.prune_neurons_in(np.array([0, 1, 2, 3]))
         self.assertIn("Cannot prune all neurons", str(ctx.exception))
 
-        # no previous GrowingModule -> AssertionError
+        # no previous GrowingModule -> TypeError
         standalone = self.create_linear_layer(in_features=5, out_features=7, bias=True)
-        with self.assertRaises(AssertionError):
-            standalone.prune_hidden_neurons_in([0])
+        with self.assertRaises(TypeError):
+            standalone.prune_neurons_in(np.array([0]))
 
     def test_get_fan_in_from_layer(self):
         """Test get_fan_in_from_layer method."""

--- a/tests/test_linear_growing_module.py
+++ b/tests/test_linear_growing_module.py
@@ -5,7 +5,6 @@ from typing import Literal
 from unittest import mock
 
 import numpy as np
-
 import torch
 
 from gromo.modules.linear_growing_module import (
@@ -555,6 +554,7 @@ class TestLinearGrowingModule(TestLinearGrowingModuleBase):
     def test_prune_neurons_in_with_growingbatchnorm(self):
         """The previous module's GrowingBatchNorm post-layer is pruned alongside the hidden dim."""
         from gromo.modules.growing_normalisation import GrowingBatchNorm1d
+
         hidden = 4
         first, second = self.create_demo_layers(
             bias=True,
@@ -594,6 +594,7 @@ class TestLinearGrowingModule(TestLinearGrowingModuleBase):
 
     def test_prune_neurons_in_with_layernorm(self):
         from gromo.modules.growing_normalisation import GrowingLayerNorm
+
         hidden = 4
         first, second = self.create_demo_layers(
             bias=True,
@@ -624,11 +625,14 @@ class TestLinearGrowingModule(TestLinearGrowingModuleBase):
 
     def test_prune_neurons_in_with_groupnorm(self):
         from gromo.modules.growing_normalisation import GrowingGroupNorm
+
         hidden = 4
         first, second = self.create_demo_layers(
             bias=True,
             hidden_features=hidden,
-            first_layer_post_layer=GrowingGroupNorm(num_groups=2, num_channels=hidden, device=global_device()),
+            first_layer_post_layer=GrowingGroupNorm(
+                num_groups=2, num_channels=hidden, device=global_device()
+            ),
         )
         gn = first.post_layer_function
         with torch.no_grad():

--- a/tests/test_linear_growing_module.py
+++ b/tests/test_linear_growing_module.py
@@ -5040,6 +5040,32 @@ class TestNeuronCountingAndGrowth(TestLinearGrowingModuleBase):
         self.assertEqual(layer1.out_features, initial_out_features_layer1)
 
 
+class TestLinearPruningValidation(TorchTestCase):
+    def test_prune_layer_validation_and_errors(self):
+        layer = LinearGrowingModule(
+            in_features=5,
+            out_features=4,
+            use_bias=True,
+            device=global_device(),
+        )
+
+        # list input validation (converting to numpy array)
+        layer.prune_layer_in([1, 3])
+        self.assertEqual(layer.in_features, 3)
+
+        # invalid type -> TypeError
+        with self.assertRaises(TypeError):
+            layer.prune_layer_in("invalid")
+        with self.assertRaises(TypeError):
+            layer.prune_layer_out("invalid")
+
+        # non-integer type -> TypeError
+        with self.assertRaises(TypeError):
+            layer.prune_layer_in(np.array([1.0, 2.0]))
+        with self.assertRaises(TypeError):
+            layer.prune_layer_out(np.array([1.0, 2.0]))
+
+
 if __name__ == "__main__":
     from unittest import main
 

--- a/tests/test_linear_growing_module.py
+++ b/tests/test_linear_growing_module.py
@@ -465,6 +465,158 @@ class TestLinearGrowingModule(TestLinearGrowingModuleBase):
         for bias in (True, False):
             self.demo_layers[bias] = self.create_demo_layers(bias)
 
+    # ------------------------------------------------------------------ #
+    # Pruning
+    # ------------------------------------------------------------------ #
+    @unittest_parametrize(({"bias": True}, {"bias": False}))
+    def test_prune_layer_out(self, bias):
+        """prune_layer_out drops the given output rows (and matching bias)."""
+        torch.manual_seed(self.config.RANDOM_SEED)
+        layer = self.create_linear_layer(in_features=5, out_features=4, bias=bias)
+        original = deepcopy(layer)
+        indices = [1, 3]
+        keep = torch.tensor([0, 2], device=global_device())
+
+        layer.prune_layer_out(indices)
+
+        self.assertEqual(layer.in_features, original.in_features)
+        self.assertEqual(layer.out_features, original.out_features - len(indices))
+        self.assertAllClose(layer.weight, original.weight.index_select(0, keep))
+        if bias:
+            self.assertAllClose(layer.bias, original.bias.index_select(0, keep))
+        # forward equivalence: pruned(x) == original(x)[:, keep]
+        x = torch.randn(self.n, 5, device=global_device())
+        self.assertAllClose(layer(x), original(x).index_select(1, keep))
+        # recreated tensor_m shape
+        self.assertEqual(
+            layer.tensor_m._shape, (layer.in_features + int(bias), layer.out_features)
+        )
+
+    @unittest_parametrize(({"bias": True}, {"bias": False}))
+    def test_prune_layer_in(self, bias):
+        """prune_layer_in drops the given input columns; bias unchanged."""
+        torch.manual_seed(self.config.RANDOM_SEED)
+        layer = self.create_linear_layer(in_features=5, out_features=4, bias=bias)
+        original = deepcopy(layer)
+        indices = [1, 3]
+        keep = torch.tensor([0, 2, 4], device=global_device())
+
+        layer.prune_layer_in(indices)
+
+        self.assertEqual(layer.in_features, original.in_features - len(indices))
+        self.assertEqual(layer.out_features, original.out_features)
+        self.assertAllClose(layer.weight, original.weight.index_select(1, keep))
+        if bias:
+            self.assertAllClose(layer.bias, original.bias)
+        # forward equivalence: zeroing the removed inputs of the original
+        # equals feeding only the kept inputs to the pruned layer
+        x = torch.randn(self.n, 5, device=global_device())
+        x_masked = x.clone()
+        x_masked[:, indices] = 0.0
+        self.assertAllClose(layer(x.index_select(1, keep)), original(x_masked))
+        # recreated stats shapes
+        use_bias = int(bias)
+        self.assertEqual(
+            layer.tensor_s._shape,
+            (layer.in_features + use_bias, layer.in_features + use_bias),
+        )
+        self.assertEqual(
+            layer.tensor_m._shape, (layer.in_features + use_bias, layer.out_features)
+        )
+
+    def test_prune_hidden_neurons_in(self):
+        """Pruning hidden neurons shrinks previous.out_features and self.in_features together."""
+        first, second = self.create_demo_layers(bias=True, hidden_features=4)
+        original_first_weight = first.weight.detach().clone()
+        original_second_weight = second.weight.detach().clone()
+        indices = [0, 2]
+        keep = torch.tensor([1, 3], device=global_device())
+
+        second.prune_hidden_neurons_in(indices)
+
+        new_hidden = 4 - len(indices)
+        self.assertEqual(first.out_features, new_hidden)
+        self.assertEqual(second.in_features, new_hidden)
+        self.assertEqual(first.out_features, second.in_features)
+        # surviving hidden neurons keep their original weights
+        self.assertAllClose(first.weight, original_first_weight.index_select(0, keep))
+        self.assertAllClose(second.weight, original_second_weight.index_select(1, keep))
+        # chain forward still works and preserves output shape
+        x = torch.randn(self.n, first.in_features, device=global_device())
+        y = second(first(x))
+        self.assertShapeEqual(y, (self.n, second.out_features))
+
+    def test_prune_hidden_neurons_in_with_batchnorm(self):
+        """The previous module's BatchNorm post-layer is pruned alongside the hidden dim."""
+        hidden = 4
+        first, second = self.create_demo_layers(
+            bias=True,
+            hidden_features=hidden,
+            first_layer_post_layer=torch.nn.BatchNorm1d(hidden, device=global_device()),
+        )
+        bn = first.post_layer_function
+        # give every channel a distinct value so we can check the right ones survive
+        with torch.no_grad():
+            bn.weight.copy_(
+                torch.arange(hidden, dtype=torch.float32, device=global_device()) + 1.0
+            )
+            bn.bias.copy_(
+                torch.arange(hidden, dtype=torch.float32, device=global_device()) + 10.0
+            )
+        bn.running_mean = (
+            torch.arange(hidden, dtype=torch.float32, device=global_device()) + 20.0
+        )
+        bn.running_var = (
+            torch.arange(hidden, dtype=torch.float32, device=global_device()) + 30.0
+        )
+        original_weight = bn.weight.detach().clone()
+        original_bias = bn.bias.detach().clone()
+        original_running_mean = bn.running_mean.clone()
+        original_running_var = bn.running_var.clone()
+
+        indices = [0, 2]
+        keep = torch.tensor([1, 3], device=global_device())
+        new_hidden = hidden - len(indices)
+
+        second.prune_hidden_neurons_in(indices)
+
+        bn = first.post_layer_function
+        self.assertEqual(bn.num_features, new_hidden)
+        self.assertAllClose(bn.weight, original_weight.index_select(0, keep))
+        self.assertAllClose(bn.bias, original_bias.index_select(0, keep))
+        self.assertAllClose(bn.running_mean, original_running_mean.index_select(0, keep))
+        self.assertAllClose(bn.running_var, original_running_var.index_select(0, keep))
+        # chain forward works with the pruned feature count
+        first.eval()
+        x = torch.randn(self.n, first.in_features, device=global_device())
+        y = second(first(x))
+        self.assertShapeEqual(y, (self.n, second.out_features))
+
+    def test_prune_hidden_neurons_in_validation(self):
+        """Empty list is a no-op; bad indices and bad wiring raise (validation precedes mutation)."""
+        first, second = self.create_demo_layers(bias=True, hidden_features=4)
+
+        # empty list -> no-op
+        second.prune_hidden_neurons_in([])
+        self.assertEqual(first.out_features, 4)
+        self.assertEqual(second.in_features, 4)
+
+        # out-of-range / negative index -> IndexError
+        with self.assertRaises(IndexError):
+            second.prune_hidden_neurons_in([4])
+        with self.assertRaises(IndexError):
+            second.prune_hidden_neurons_in([-1])
+
+        # pruning all hidden neurons -> ValueError
+        with self.assertRaises(ValueError) as ctx:
+            second.prune_hidden_neurons_in([0, 1, 2, 3])
+        self.assertIn("Cannot prune all neurons", str(ctx.exception))
+
+        # no previous GrowingModule -> AssertionError
+        standalone = self.create_linear_layer(in_features=5, out_features=7, bias=True)
+        with self.assertRaises(AssertionError):
+            standalone.prune_hidden_neurons_in([0])
+
     def test_get_fan_in_from_layer(self):
         """Test get_fan_in_from_layer method."""
         layer = self.demo_layers[True][0]


### PR DESCRIPTION
## Summary

Adds neuron/channel pruning to gromo — the symmetric counterpart of layer
growing. Lets you shrink the hidden dim between two growing modules.

Closes #257 

## Changes

- `GrowingModule.prune_layer(indices)` — removes hidden-dim neurons: drops
  `previous_module` output rows, shrinks BatchNorm in the post-layer function,
  drops `self` input columns, resets stats.
- `LinearGrowingModule.prune_layer_in/out` — rebuild `self.layer` as a smaller
  `nn.Linear`.
- `Conv2dGrowingModule.prune_layer_in/out` — rebuild `self.layer` as a smaller
  `nn.Conv2d` (preserves stride/padding/dilation/groups).


## Out of scope

Pruning criteria (which neurons to drop) — lives in the experiment layer.

## TODO before merge

- [OK ] Add tests under `tests/` (linear, conv, BatchNorm, edge cases).
