### PR TITLE
enh: Implement the "normal" variation of Kaiming init

### DIFF
--- a/docs/source/whats_new.rst
+++ b/docs/source/whats_new.rst
@@ -20,6 +20,7 @@ Develop branch
 Enhancements
 ~~~~~~~~~~~~
 
+- Add Kaiming-normal and copy-normal initializations for layer extensions: ``kaiming_initialization`` and ``copy_initialization_variance`` (renamed from ``copy_uniform_initialization``) gain a ``distribution`` argument, exposed through the new ``"kaiming_normal"`` and ``"copy_normal"`` keys of ``create_layer_extensions`` (:gh:`259` by `Théo Rudkiewicz`_).
 - Refactored growing MLP containers to use `SequentialGrowingContainer` for a more unified model manipulation interface (:gh:`253` by `Pako Maxence TEKOU`_)
 - Example for `GrowingGraphNetwork` and `GrowingDAG` usage (:gh:`252` by `Stella Douka`_)
 - Add an empirical Fisher (loss-gradient covariance) as an optional preconditioner for both optimal-delta weight updates and rank-k neuron extension computations (:gh:`250` by `Théo Rudkiewicz`_).

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -1,4 +1,5 @@
 import warnings
+from functools import partial
 from typing import Any, Iterator, Literal, Protocol, get_args, runtime_checkable
 
 import numpy as np
@@ -3534,22 +3535,24 @@ class GrowingModule(torch.nn.Module):
             ext_in.weight.data.add_(torch.randn_like(ext_in.weight.data) * noise_std)
 
     @torch.no_grad()
-    def copy_uniform_initialization(
+    def copy_initialisation_variance(
         self,
         tensor: torch.Tensor,
         reference_tensor: torch.Tensor | None,
         fan_in: int,
+        distribution: Literal["uniform", "normal"] = "uniform",
     ) -> None:
         """
-        Initialize tensor with uniform law aligned on reference
+        Initialize tensor with the empirical variance of the reference.
 
-        Initialize the tensor with a uniform law with bounds
-        -sqrt(std(W)), sqrt(std(W))
-        where std(W) is the empirical standard deviation of the reference_tensor
-        if the reference_tensor has a non-zero variance.
-        Otherwise, use bounds
-        -sqrt(6 / fan_in), sqrt(6 / fan_in)
-        where fan_in is the number of input features of the reference tensor + extension.
+        Initialize the tensor with a law whose standard deviation matches
+        std(W), the empirical standard deviation of the reference_tensor, when
+        the reference_tensor has a non-zero variance:
+        - ``distribution="uniform"``: uniform law on
+          ``[-sqrt(3) * std(W), sqrt(3) * std(W)]`` (variance ``std(W)**2``);
+        - ``distribution="normal"``: normal law ``N(0, std(W)**2)``.
+        Otherwise (missing reference or zero variance), fall back to
+        ``kaiming_initialization`` with the same ``distribution``.
 
         Parameters
         ----------
@@ -3559,18 +3562,27 @@ class GrowingModule(torch.nn.Module):
             tensor to get the standard deviation from or None to use Kaiming init
         fan_in: int
             number of input features of the base tensor + extension
+        distribution: Literal["uniform", "normal"]
+            sampling law to use, default ``"uniform"``.
         """
-        # Fallback to Kaiming uniform initialization bounds
+        # Fallback to Kaiming initialization (same distribution)
         if (
             reference_tensor is None
             or reference_tensor.numel() < 2
             or (std_dev := reference_tensor.std().item()) == 0
         ):
-            self.kaiming_initialization(tensor, reference_tensor, fan_in)
-        else:
-            # Initialize with uniform distribution
+            self.kaiming_initialization(
+                tensor, reference_tensor, fan_in, distribution=distribution
+            )
+        elif distribution == "normal":
+            torch.nn.init.normal_(tensor, mean=0.0, std=std_dev)
+        elif distribution == "uniform":
             bound = 3.0**0.5 * std_dev
             torch.nn.init.uniform_(tensor, -bound, bound)
+        else:
+            raise ValueError(
+                f"Unknown distribution {distribution!r}, expected 'uniform' or 'normal'."
+            )
 
     @torch.no_grad()
     def kaiming_initialization(
@@ -3578,9 +3590,10 @@ class GrowingModule(torch.nn.Module):
         tensor: torch.Tensor,
         reference_tensor: torch.Tensor | None,
         fan_in: int,
+        distribution: Literal["uniform", "normal"] = "uniform",
     ) -> None:
         """
-        Initialize tensor with Kaiming.
+        Initialize tensor with Kaiming (variance ``2 / fan_in``, ReLU gain).
 
         Parameters
         ----------
@@ -3590,10 +3603,21 @@ class GrowingModule(torch.nn.Module):
             Unused
         fan_in: int
             number of input features of the base tensor + extension
+        distribution: Literal["uniform", "normal"]
+            sampling law to use, default ``"uniform"``:
+            - ``"uniform"``: ``U(-sqrt(6 / fan_in), sqrt(6 / fan_in))``;
+            - ``"normal"``: ``N(0, 2 / fan_in)``.
         """
         del reference_tensor
-        bound = (2.0 * 3.0 / fan_in) ** 0.5
-        torch.nn.init.uniform_(tensor, -bound, bound)
+        if distribution == "normal":
+            torch.nn.init.normal_(tensor, mean=0.0, std=(2.0 / fan_in) ** 0.5)
+        elif distribution == "uniform":
+            bound = (2.0 * 3.0 / fan_in) ** 0.5
+            torch.nn.init.uniform_(tensor, -bound, bound)
+        else:
+            raise ValueError(
+                f"Unknown distribution {distribution!r}, expected 'uniform' or 'normal'."
+            )
 
     @torch.no_grad()
     def create_layer_extensions(
@@ -3642,12 +3666,14 @@ class GrowingModule(torch.nn.Module):
             *extension_size*.
         output_extension_init: str
             Initialisation method for the output extension.  Must be one of
-            the keys in ``known_inits`` (``"copy_uniform"``, ``"kaiming"``,
-            ``"zeros"``), default ``"copy_uniform"``.
+            the keys in ``known_inits`` (``"copy_uniform"``, ``"copy_normal"``,
+            ``"kaiming"``, ``"kaiming_normal"``, ``"zeros"``), default
+            ``"copy_uniform"``.
         input_extension_init: str
             Initialisation method for the input extension.  Must be one of
-            the keys in ``known_inits`` (``"copy_uniform"``, ``"kaiming"``,
-            ``"zeros"``), default ``"copy_uniform"``.
+            the keys in ``known_inits`` (``"copy_uniform"``, ``"copy_normal"``,
+            ``"kaiming"``, ``"kaiming_normal"``, ``"zeros"``), default
+            ``"copy_uniform"``.
         neuron_pairing: _KNOWN_NEURON_PAIRINGS_TYPE | None
             Neuron-pairing strategy applied after initialisation.
             ``"none"`` (default) or ``"vv_z_negz"``.
@@ -3724,8 +3750,14 @@ class GrowingModule(torch.nn.Module):
         self.create_layer_in_extension(input_extension_size)
 
         known_inits = {
-            "copy_uniform": self.copy_uniform_initialization,
-            "kaiming": self.kaiming_initialization,
+            "copy_uniform": partial(
+                self.copy_initialisation_variance, distribution="uniform"
+            ),
+            "copy_normal": partial(
+                self.copy_initialisation_variance, distribution="normal"
+            ),
+            "kaiming": partial(self.kaiming_initialization, distribution="uniform"),
+            "kaiming_normal": partial(self.kaiming_initialization, distribution="normal"),
             "zeros": lambda tensor, _, __: torch.nn.init.zeros_(tensor),
             # Future initializations can be added here
         }

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -3535,7 +3535,7 @@ class GrowingModule(torch.nn.Module):
             ext_in.weight.data.add_(torch.randn_like(ext_in.weight.data) * noise_std)
 
     @torch.no_grad()
-    def copy_initialisation_variance(
+    def copy_initialization_variance(
         self,
         tensor: torch.Tensor,
         reference_tensor: torch.Tensor | None,
@@ -3564,6 +3564,11 @@ class GrowingModule(torch.nn.Module):
             number of input features of the base tensor + extension
         distribution: Literal["uniform", "normal"]
             sampling law to use, default ``"uniform"``.
+
+        Raises
+        ------
+        ValueError
+            If ``distribution`` is not ``"uniform"`` or ``"normal"``.
         """
         # Fallback to Kaiming initialization (same distribution)
         if (
@@ -3607,6 +3612,11 @@ class GrowingModule(torch.nn.Module):
             sampling law to use, default ``"uniform"``:
             - ``"uniform"``: ``U(-sqrt(6 / fan_in), sqrt(6 / fan_in))``;
             - ``"normal"``: ``N(0, 2 / fan_in)``.
+
+        Raises
+        ------
+        ValueError
+            If ``distribution`` is not ``"uniform"`` or ``"normal"``.
         """
         del reference_tensor
         if distribution == "normal":
@@ -3648,8 +3658,8 @@ class GrowingModule(torch.nn.Module):
            rescaled weights as reference).
         2. **Extension creation** — physical extension layers are allocated
            at their final (post-pairing) size.
-        3. **Initialisation** — the first half of each extension is
-           initialised when ``neuron_pairing`` is active, the full extension
+        3. **Initialization** — the first half of each extension is
+           initialized when ``neuron_pairing`` is active, the full extension
            otherwise.
         4. **Neuron pairing** — the already-allocated second half of each
            extension is filled in place via (V,V)/(Z,-Z).
@@ -3665,17 +3675,17 @@ class GrowingModule(torch.nn.Module):
             Size of the input extension to create, if ``None`` use
             *extension_size*.
         output_extension_init: str
-            Initialisation method for the output extension.  Must be one of
+            Initialization method for the output extension.  Must be one of
             the keys in ``known_inits`` (``"copy_uniform"``, ``"copy_normal"``,
             ``"kaiming"``, ``"kaiming_normal"``, ``"zeros"``), default
             ``"copy_uniform"``.
         input_extension_init: str
-            Initialisation method for the input extension.  Must be one of
+            Initialization method for the input extension.  Must be one of
             the keys in ``known_inits`` (``"copy_uniform"``, ``"copy_normal"``,
             ``"kaiming"``, ``"kaiming_normal"``, ``"zeros"``), default
             ``"copy_uniform"``.
         neuron_pairing: _KNOWN_NEURON_PAIRINGS_TYPE | None
-            Neuron-pairing strategy applied after initialisation.
+            Neuron-pairing strategy applied after initialization.
             ``"none"`` (default) or ``"vv_z_negz"``.
             /!/ When ``neuron_pairing`` is active, ``extension_size`` (and
             ``output_extension_size`` / ``input_extension_size``) is the
@@ -3751,10 +3761,10 @@ class GrowingModule(torch.nn.Module):
 
         known_inits = {
             "copy_uniform": partial(
-                self.copy_initialisation_variance, distribution="uniform"
+                self.copy_initialization_variance, distribution="uniform"
             ),
             "copy_normal": partial(
-                self.copy_initialisation_variance, distribution="normal"
+                self.copy_initialization_variance, distribution="normal"
             ),
             "kaiming": partial(self.kaiming_initialization, distribution="uniform"),
             "kaiming_normal": partial(self.kaiming_initialization, distribution="normal"),
@@ -3770,7 +3780,7 @@ class GrowingModule(torch.nn.Module):
                 )
 
         # Step 3: Initialize extensions. When pairing is active only the
-        # first half is initialised; the second half is filled by
+        # first half is initialized; the second half is filled by
         # apply_neuron_pairing.
         half_in = input_extension_size // 2 if neuron_pairing else None
         half_out = output_extension_size // 2 if neuron_pairing else None

--- a/tests/test_variance_transfer.py
+++ b/tests/test_variance_transfer.py
@@ -1147,7 +1147,7 @@ class TestCoverageSmoke(TorchTestCase):
             block.second_layer.apply_neuron_pairing(neuron_pairing="vv_z_negz")
 
     def test_copy_uniform_initialization(self):
-        """create_layer_extensions with copy_uniform init hits copy_uniform_initialization."""
+        """create_layer_extensions with copy_uniform init hits copy_initialisation_variance."""
         block = _make_conv_block(h_t=8, device=self.device)
         block.create_layer_extensions(
             extension_size=4,

--- a/tests/test_variance_transfer.py
+++ b/tests/test_variance_transfer.py
@@ -1147,7 +1147,7 @@ class TestCoverageSmoke(TorchTestCase):
             block.second_layer.apply_neuron_pairing(neuron_pairing="vv_z_negz")
 
     def test_copy_uniform_initialization(self):
-        """create_layer_extensions with copy_uniform init hits copy_initialisation_variance."""
+        """create_layer_extensions with copy_uniform init hits copy_initialization_variance."""
         block = _make_conv_block(h_t=8, device=self.device)
         block.create_layer_extensions(
             extension_size=4,
@@ -1167,6 +1167,67 @@ class TestCoverageSmoke(TorchTestCase):
             output_extension_init="copy_uniform",
             input_extension_init="copy_uniform",
         )
+
+    def test_kaiming_normal_initialization(self):
+        """create_layer_extensions with kaiming_normal hits the normal branch."""
+        block = _make_conv_block(h_t=8, device=self.device)
+        block.create_layer_extensions(
+            extension_size=4,
+            output_extension_init="kaiming_normal",
+            input_extension_init="kaiming_normal",
+        )
+        self.assertIsNotNone(block.first_layer.extended_output_layer)
+        self.assertIsNotNone(block.second_layer.extended_input_layer)
+
+    def test_copy_normal_initialization(self):
+        """create_layer_extensions with copy_normal hits the normal branch."""
+        block = _make_conv_block(h_t=8, device=self.device)
+        block.create_layer_extensions(
+            extension_size=4,
+            output_extension_init="copy_normal",
+            input_extension_init="copy_normal",
+        )
+        self.assertIsNotNone(block.second_layer.extended_input_layer)
+
+    def test_copy_normal_fallback_to_kaiming(self):
+        """copy_normal with zero-variance reference falls back to kaiming (normal)."""
+        block = _make_conv_block(h_t=8, device=self.device)
+        # Constant weights => zero variance => kaiming-normal fallback.
+        block.first_layer.weight.data.fill_(0.5)
+        block.second_layer.weight.data.fill_(0.5)
+        block.create_layer_extensions(
+            extension_size=4,
+            output_extension_init="copy_normal",
+            input_extension_init="copy_normal",
+        )
+        self.assertIsNotNone(block.second_layer.extended_input_layer)
+
+    def test_kaiming_initialization_bad_distribution_raises(self):
+        """kaiming_initialization with an unknown distribution raises ValueError."""
+        block = _make_conv_block(h_t=8, device=self.device)
+        tensor = torch.empty(4, 8, device=self.device)
+        with self.assertRaises(ValueError):
+            block.second_layer.kaiming_initialization(
+                tensor,
+                None,
+                8,
+                distribution="bad",  # type: ignore
+            )
+
+    def test_copy_initialization_variance_bad_distribution_raises(self):
+        """copy_initialization_variance with an unknown distribution raises ValueError."""
+        block = _make_conv_block(h_t=8, device=self.device)
+        tensor = torch.empty(4, 8, device=self.device)
+        # Non-zero variance reference so we reach the distribution dispatch
+        # (and not the Kaiming fallback).
+        reference = torch.randn(4, 8, device=self.device)
+        with self.assertRaises(ValueError):
+            block.second_layer.copy_initialization_variance(
+                tensor,
+                reference,
+                8,
+                distribution="bad",  # type: ignore
+            )
 
     def test_extension_size_overrides(self):
         """Explicit output_extension_size and input_extension_size."""


### PR DESCRIPTION
For now initilisation methods are ony available in "uniform" version,  this implement the "normal" version