### PR TITLE
feat: joint Net2Wider function-preserving growth path

### DIFF
--- a/src/gromo/containers/growing_block.py
+++ b/src/gromo/containers/growing_block.py
@@ -596,6 +596,8 @@ class GrowingBlock(GrowingContainer):
         neuron_pairing: GrowingModule._KNOWN_NEURON_PAIRINGS_TYPE | None = None,
         rescaling: GrowingModule._KNOWN_RESCALING_STRATEGIES_TYPE | None = None,
         noise_ratio: float = 0.001,
+        selected_indices: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
     ) -> None:
         """
         Create the layer input and output extensions of given sizes.
@@ -616,10 +618,12 @@ class GrowingBlock(GrowingContainer):
             *extension_size*.
         output_extension_init: str
             Initialisation method for the output extension.  Possible values
-            include ``"copy_uniform"``, ``"kaiming"``, ``"zeros"``.
+            include ``"copy_uniform"``, ``"kaiming"``, ``"zeros"``,
+            ``"net2wider"``.
         input_extension_init: str
             Initialisation method for the input extension.  Possible values
-            include ``"copy_uniform"``, ``"kaiming"``, ``"zeros"``.
+            include ``"copy_uniform"``, ``"kaiming"``, ``"zeros"``,
+            ``"net2wider"``.
         neuron_pairing: GrowingModule._KNOWN_NEURON_PAIRINGS_TYPE | None
             Neuron-pairing strategy.  ``None`` (default) or
             ``"vv_z_negz"``.
@@ -631,6 +635,10 @@ class GrowingBlock(GrowingContainer):
             Fraction of the standard deviation of the input extension weights
             used as noise for symmetry breaking after neuron pairing.
             Default ``0.001``.
+        selected_indices: torch.Tensor | None
+            Optional replica index map for the joint ``net2wider`` path.
+        generator: torch.Generator | None
+            Optional RNG for sampling ``selected_indices`` when not injected.
         """
         self.second_layer.create_layer_extensions(
             extension_size=extension_size,
@@ -641,6 +649,8 @@ class GrowingBlock(GrowingContainer):
             neuron_pairing=neuron_pairing,
             rescaling=rescaling,
             noise_ratio=noise_ratio,
+            selected_indices=selected_indices,
+            generator=generator,
         )
 
     def apply_rescaling(

--- a/src/gromo/modules/growing_module.py
+++ b/src/gromo/modules/growing_module.py
@@ -3558,6 +3558,139 @@ class GrowingModule(torch.nn.Module):
         bound = (2.0 * 3.0 / fan_in) ** 0.5
         torch.nn.init.uniform_(tensor, -bound, bound)
 
+    def _assert_groups_one_for_net2wider(self) -> None:
+        """Reject depthwise / grouped convolution for Net2Wider v1."""
+        for module in (self, self.previous_module):
+            layer = getattr(module, "layer", None)
+            groups = getattr(layer, "groups", 1)
+            if groups != 1:
+                raise ValueError(
+                    f"net2wider requires groups==1, got groups={groups} on "
+                    f"{getattr(module, 'name', module)}."
+                )
+
+    @torch.no_grad()
+    def _apply_net2wider_extensions(
+        self,
+        extension_size: int,
+        selected_indices: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
+    ) -> torch.Tensor:
+        """Fill both extensions with a shared Net2Wider replica map.
+
+        Samples (or accepts) replica indices once, copies those neurons into
+        the previous layer's output extension, then scales the next layer's
+        existing input fan-in and extension columns by ``1 / c_j`` where
+        ``c_j = 1 + replica_count(j)``.
+
+        Parameters
+        ----------
+        extension_size: int
+            Number of neurons / channels to add (same on both sides).
+        selected_indices: torch.Tensor | None
+            Optional pre-chosen indices of shape ``(extension_size,)`` into
+            the previous layer's output axis. When ``None``, indices are
+            sampled with ``generator`` (or the global RNG).
+        generator: torch.Generator | None
+            Optional generator used only when ``selected_indices`` is
+            ``None``.
+
+        Returns
+        -------
+        torch.Tensor
+            The replica index map that was applied (also stored on
+            ``self.net2wider_selected_indices``).
+
+        Raises
+        ------
+        ValueError
+            If extensions are missing, sizes mismatch, or indices are invalid.
+        """
+        assert isinstance(self.previous_module, GrowingModule)
+        prev = self.previous_module
+        ext_out = prev.extended_output_layer
+        ext_in = self.extended_input_layer
+        if ext_out is None or ext_in is None:
+            raise ValueError(
+                "net2wider requires both extended_output_layer (previous) and "
+                "extended_input_layer (current) to be allocated."
+            )
+
+        num_base = prev.weight.shape[0]
+        if extension_size <= 0:
+            raise ValueError(
+                f"net2wider extension_size must be positive, got {extension_size}."
+            )
+        if ext_out.weight.shape[0] != extension_size:
+            raise ValueError(
+                f"Output extension size {ext_out.weight.shape[0]} does not match "
+                f"requested net2wider extension_size={extension_size}."
+            )
+        if ext_in.weight.shape[1] != extension_size:
+            raise ValueError(
+                f"Input extension size {ext_in.weight.shape[1]} does not match "
+                f"requested net2wider extension_size={extension_size}."
+            )
+
+        if selected_indices is None:
+            selected_indices = torch.randint(
+                0,
+                num_base,
+                (extension_size,),
+                generator=generator,
+                dtype=torch.long,
+            )
+        else:
+            selected_indices = selected_indices.detach().to(dtype=torch.long).reshape(-1)
+            if selected_indices.numel() != extension_size:
+                raise ValueError(
+                    f"selected_indices must have length {extension_size}, "
+                    f"got {selected_indices.numel()}."
+                )
+            if bool((selected_indices < 0).any() or (selected_indices >= num_base).any()):
+                raise ValueError(
+                    f"selected_indices must be in [0, {num_base}), "
+                    f"got min={int(selected_indices.min())}, "
+                    f"max={int(selected_indices.max())}."
+                )
+
+        selected_indices = selected_indices.to(device=prev.weight.device)
+        replica_counts = torch.ones(
+            num_base, dtype=torch.float32, device=prev.weight.device
+        )
+        replica_counts.scatter_add_(
+            0,
+            selected_indices,
+            torch.ones(extension_size, dtype=torch.float32, device=prev.weight.device),
+        )
+
+        # Output extension: unscaled copies of selected previous-layer neurons.
+        ext_out.weight.copy_(prev.weight[selected_indices])
+        if ext_out.bias is not None:
+            if prev.bias is None:
+                raise ValueError(
+                    "Previous layer has no bias but its output extension does."
+                )
+            ext_out.bias.copy_(prev.bias[selected_indices])
+
+        # Scale next-layer existing fan-in (originals) by 1/c_j, then copy
+        # those already-scaled columns into the input extension (replicas).
+        next_weight = self.weight
+        for j in range(num_base):
+            count = float(replica_counts[j].item())
+            if count != 1.0:
+                next_weight[:, j].div_(count)
+
+        for i, src_idx in enumerate(selected_indices.tolist()):
+            ext_in.weight[:, i].copy_(next_weight[:, src_idx])
+
+        if ext_in.bias is not None:
+            torch.nn.init.zeros_(ext_in.bias)
+
+        self.net2wider_selected_indices = selected_indices
+        prev.net2wider_selected_indices = selected_indices
+        return selected_indices
+
     @torch.no_grad()
     def create_layer_extensions(
         self,
@@ -3569,6 +3702,8 @@ class GrowingModule(torch.nn.Module):
         neuron_pairing: _KNOWN_NEURON_PAIRINGS_TYPE | None = None,
         rescaling: _KNOWN_RESCALING_STRATEGIES_TYPE | None = None,
         noise_ratio: float = 0.001,
+        selected_indices: torch.Tensor | None = None,
+        generator: torch.Generator | None = None,
     ) -> None:
         """
         Create extension for layer input and output.
@@ -3593,6 +3728,14 @@ class GrowingModule(torch.nn.Module):
         4. **Neuron pairing** — the already-allocated second half of each
            extension is filled in place via (V,V)/(Z,-Z).
 
+        When both ``input_extension_init`` and ``output_extension_init`` are
+        ``"net2wider"``, a **joint** function-preserving path is used instead:
+        a shared replica map fills both extensions and scales the next-layer
+        existing fan-in by ``1/c_j``. Mixing ``net2wider`` with another init,
+        ``neuron_pairing``, or ``rescaling`` raises ``ValueError``. BatchNorm
+        between the pair and residual/skip growth are out of scope for v1
+        (Linear / BN-free mechanism bar).
+
         Parameters
         ----------
         extension_size: int
@@ -3606,11 +3749,13 @@ class GrowingModule(torch.nn.Module):
         output_extension_init: str
             Initialisation method for the output extension.  Must be one of
             the keys in ``known_inits`` (``"copy_uniform"``, ``"kaiming"``,
-            ``"zeros"``), default ``"copy_uniform"``.
+            ``"zeros"``) or ``"net2wider"`` (joint path; both sides required),
+            default ``"copy_uniform"``.
         input_extension_init: str
             Initialisation method for the input extension.  Must be one of
             the keys in ``known_inits`` (``"copy_uniform"``, ``"kaiming"``,
-            ``"zeros"``), default ``"copy_uniform"``.
+            ``"zeros"``) or ``"net2wider"`` (joint path; both sides required),
+            default ``"copy_uniform"``.
         neuron_pairing: _KNOWN_NEURON_PAIRINGS_TYPE | None
             Neuron-pairing strategy applied after initialisation.
             ``"none"`` (default) or ``"vv_z_negz"``.
@@ -3618,15 +3763,24 @@ class GrowingModule(torch.nn.Module):
             ``output_extension_size`` / ``input_extension_size``) is the
             **final** size, pairing included, and must be even. A
             ``ValueError`` is raised otherwise.
+            Incompatible with ``net2wider``.
         rescaling: _KNOWN_RESCALING_STRATEGIES_TYPE | None
             Variance-transfer rescaling strategy applied before extension
             creation.  ``"none"`` (default), ``"default_vt"``,
             ``"vt_constraint_old_shape"``, or ``"vt_constraint_new_shape"``.
+            Incompatible with ``net2wider``.
         noise_ratio: float
             Fraction of the standard deviation of the input extension weights
             used as the noise level for symmetry breaking after neuron
             pairing.  Set to ``0`` for exact function preservation.
             Default ``0.001``.
+        selected_indices: torch.Tensor | None
+            Optional replica index map for the joint ``net2wider`` path
+            (length = extension size). Ignored for other inits. Exposed for
+            probe↔gromo cross-checks.
+        generator: torch.Generator | None
+            Optional RNG for sampling ``selected_indices`` when not injected.
+            Used only by the joint ``net2wider`` path.
 
         Notes
         -----
@@ -3651,7 +3805,8 @@ class GrowingModule(torch.nn.Module):
         ------
         ValueError
             If unknown initialization method, rescaling strategy, or neuron
-            pairing.
+            pairing; if ``net2wider`` is mixed with another init / pairing /
+            rescaling; if Conv ``groups != 1``.
         """
         if output_extension_size is None:
             output_extension_size = extension_size
@@ -3661,6 +3816,45 @@ class GrowingModule(torch.nn.Module):
             f"The layer {self.name} has no previous module."
             "Therefore, neuron addition is not possible."
         )
+
+        uses_net2wider = (
+            input_extension_init == "net2wider" or output_extension_init == "net2wider"
+        )
+        if uses_net2wider:
+            if (
+                input_extension_init != "net2wider"
+                or output_extension_init != "net2wider"
+            ):
+                raise ValueError(
+                    "net2wider requires both input_extension_init and "
+                    "output_extension_init to be 'net2wider' (joint replica map). "
+                    f"Got input={input_extension_init!r}, "
+                    f"output={output_extension_init!r}."
+                )
+            if neuron_pairing is not None:
+                raise ValueError(
+                    "net2wider cannot be combined with neuron_pairing="
+                    f"{neuron_pairing!r}."
+                )
+            if rescaling is not None:
+                raise ValueError(
+                    f"net2wider cannot be combined with rescaling={rescaling!r}."
+                )
+            if input_extension_size != output_extension_size:
+                raise ValueError(
+                    "net2wider requires equal input and output extension sizes "
+                    f"(got input={input_extension_size}, "
+                    f"output={output_extension_size})."
+                )
+            self._assert_groups_one_for_net2wider()
+            self.previous_module.create_layer_out_extension(output_extension_size)
+            self.create_layer_in_extension(input_extension_size)
+            self._apply_net2wider_extensions(
+                extension_size=input_extension_size,
+                selected_indices=selected_indices,
+                generator=generator,
+            )
+            return
 
         if neuron_pairing is not None:
             for param_name, value in (
@@ -3697,7 +3891,7 @@ class GrowingModule(torch.nn.Module):
             if init not in known_inits:
                 raise ValueError(
                     f"Unknown initialization method '{init}'. "
-                    f"Available methods are: {list(known_inits.keys())}."
+                    f"Available methods are: {[*list(known_inits.keys()), 'net2wider']}."
                 )
 
         # Step 3: Initialize extensions. When pairing is active only the

--- a/src/gromo/modules/linear_growing_module.py
+++ b/src/gromo/modules/linear_growing_module.py
@@ -764,12 +764,22 @@ class LinearGrowingModule(GrowingModule):
                 f"The new layer should have a bias ({bias is not None=}) if and only if "
                 f"the main layer bias ({self.use_bias =}) is not None."
             )
-        new_layer = torch.nn.Linear(
-            weight.shape[1], weight.shape[0], bias=(bias is not None), device=self.device
+        weight_on = weight.to(device=self.device, dtype=self.layer.weight.dtype)
+        bias_on = (
+            bias.to(device=self.device, dtype=self.layer.bias.dtype)
+            if bias is not None
+            else None
         )
-        new_layer.weight = torch.nn.Parameter(weight)
-        if bias is not None:
-            new_layer.bias = torch.nn.Parameter(bias)
+        new_layer = torch.nn.Linear(
+            weight_on.shape[1],
+            weight_on.shape[0],
+            bias=(bias_on is not None),
+            device=self.device,
+            dtype=weight_on.dtype,
+        )
+        new_layer.weight = torch.nn.Parameter(weight_on)
+        if bias_on is not None:
+            new_layer.bias = torch.nn.Parameter(bias_on)
         return new_layer
 
     def add_parameters(  # type: ignore

--- a/tests/test_net2wider_initializer.py
+++ b/tests/test_net2wider_initializer.py
@@ -1,0 +1,341 @@
+"""Tests for joint Net2Wider function-preserving growth."""
+
+from __future__ import annotations
+
+import unittest
+
+import torch
+
+from gromo.modules.conv2d_growing_module import FullConv2dGrowingModule
+from gromo.modules.linear_growing_module import LinearGrowingModule
+from gromo.utils.utils import global_device
+from tests.torch_unittest import TorchTestCase
+
+
+FP_ATOL = 1e-4
+
+
+def _oracle_widen_linear(
+    wa: torch.Tensor,
+    ba: torch.Tensor | None,
+    wb: torch.Tensor,
+    selected_indices: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor]:
+    """Reference Net2Wider on a Linear→Linear pair (shared replica map)."""
+    num_base = wa.shape[0]
+    n_added = selected_indices.numel()
+    replica_counts = torch.ones(num_base, dtype=torch.float32, device=wa.device)
+    replica_counts.scatter_add_(
+        0,
+        selected_indices.to(device=wa.device),
+        torch.ones(n_added, dtype=torch.float32, device=wa.device),
+    )
+
+    wa_new = torch.cat([wa, wa[selected_indices]], dim=0)
+    ba_new = None
+    if ba is not None:
+        ba_new = torch.cat([ba, ba[selected_indices]], dim=0)
+
+    wb_new = torch.cat([wb.clone(), wb[:, selected_indices].clone()], dim=1)
+    for j in range(num_base):
+        count = float(replica_counts[j].item())
+        indices = [j] + [
+            num_base + i for i, src in enumerate(selected_indices.tolist()) if src == j
+        ]
+        for idx in indices:
+            wb_new[:, idx] = wb_new[:, idx] / count
+    return wa_new, ba_new, wb_new
+
+
+class TestNet2WiderJointLinear(TorchTestCase):
+    """Linear→Linear joint Net2Wider mechanism tests."""
+
+    def setUp(self) -> None:
+        torch.manual_seed(0)
+        self.device = global_device()
+
+    def _make_pair(
+        self,
+        in_features: int = 5,
+        hidden: int = 4,
+        out_features: int = 3,
+        bias: bool = True,
+        activation: torch.nn.Module | None = None,
+    ) -> tuple[LinearGrowingModule, LinearGrowingModule]:
+        if activation is None:
+            activation = torch.nn.Identity()
+        first = LinearGrowingModule(
+            in_features,
+            hidden,
+            use_bias=bias,
+            name="first",
+            device=self.device,
+            post_layer_function=activation,
+        )
+        second = LinearGrowingModule(
+            hidden,
+            out_features,
+            use_bias=bias,
+            name="second",
+            previous_module=first,
+            device=self.device,
+        )
+        with torch.no_grad():
+            first.weight.normal_(0.0, 0.5)
+            second.weight.normal_(0.0, 0.5)
+            if first.bias is not None:
+                first.bias.uniform_(-0.3, 0.3)
+            if second.bias is not None:
+                second.bias.uniform_(-0.3, 0.3)
+        return first, second
+
+    def _forward_pair(
+        self,
+        first: LinearGrowingModule,
+        second: LinearGrowingModule,
+        x: torch.Tensor,
+        *,
+        use_extensions: bool,
+    ) -> torch.Tensor:
+        if use_extensions:
+            first.scaling_factor = 1.0  # type: ignore[assignment]
+            second.scaling_factor = 1.0  # type: ignore[assignment]
+            h, h_ext = first.extended_forward(x)
+            y, y_ext = second.extended_forward(h, h_ext)
+            assert y_ext is None
+            return y
+        return second(first(x))
+
+    def test_function_preservation_pre_and_post_apply_change(self) -> None:
+        first, second = self._make_pair()
+        x = torch.randn(16, first.in_features, device=self.device)
+        selected = torch.tensor([0, 2, 2, 1], dtype=torch.long)
+
+        with torch.no_grad():
+            y_before = self._forward_pair(first, second, x, use_extensions=False).clone()
+
+        second.create_layer_extensions(
+            extension_size=4,
+            output_extension_init="net2wider",
+            input_extension_init="net2wider",
+            selected_indices=selected,
+        )
+
+        with torch.no_grad():
+            y_pre = self._forward_pair(first, second, x, use_extensions=True)
+        self.assertAllClose(y_before, y_pre, atol=FP_ATOL)
+
+        second.apply_change(scaling_factor=1.0, extension_size=4)
+        second.delete_update(include_previous=True)
+
+        with torch.no_grad():
+            y_post = self._forward_pair(first, second, x, use_extensions=False)
+        self.assertAllClose(y_before, y_post, atol=FP_ATOL)
+        self.assertEqual(first.out_features, 8)
+        self.assertEqual(second.in_features, 8)
+        self.assertTrue(torch.equal(second.net2wider_selected_indices.cpu(), selected))
+
+    def test_two_step_cumulative_growth(self) -> None:
+        first, second = self._make_pair(hidden=3)
+        x = torch.randn(8, first.in_features, device=self.device)
+        with torch.no_grad():
+            y0 = self._forward_pair(first, second, x, use_extensions=False).clone()
+
+        second.create_layer_extensions(
+            extension_size=2,
+            output_extension_init="net2wider",
+            input_extension_init="net2wider",
+            selected_indices=torch.tensor([0, 1]),
+        )
+        second.apply_change(scaling_factor=1.0, extension_size=2)
+        second.delete_update(include_previous=True)
+
+        with torch.no_grad():
+            y1 = self._forward_pair(first, second, x, use_extensions=False)
+        self.assertAllClose(y0, y1, atol=FP_ATOL)
+
+        second.create_layer_extensions(
+            extension_size=3,
+            output_extension_init="net2wider",
+            input_extension_init="net2wider",
+            selected_indices=torch.tensor([0, 0, 4]),
+        )
+        second.apply_change(scaling_factor=1.0, extension_size=3)
+        second.delete_update(include_previous=True)
+
+        with torch.no_grad():
+            y2 = self._forward_pair(first, second, x, use_extensions=False)
+        self.assertAllClose(y0, y2, atol=FP_ATOL)
+        self.assertEqual(first.out_features, 8)
+        self.assertEqual(second.in_features, 8)
+
+    def test_rejects_output_only_with_kaiming_input(self) -> None:
+        _, second = self._make_pair()
+        with self.assertRaisesRegex(ValueError, "both input_extension_init"):
+            second.create_layer_extensions(
+                extension_size=2,
+                output_extension_init="net2wider",
+                input_extension_init="kaiming",
+            )
+
+    def test_rejects_neuron_pairing(self) -> None:
+        _, second = self._make_pair()
+        with self.assertRaisesRegex(ValueError, "neuron_pairing"):
+            second.create_layer_extensions(
+                extension_size=2,
+                output_extension_init="net2wider",
+                input_extension_init="net2wider",
+                neuron_pairing="vv_z_negz",
+            )
+
+    def test_rejects_rescaling(self) -> None:
+        _, second = self._make_pair()
+        with self.assertRaisesRegex(ValueError, "rescaling"):
+            second.create_layer_extensions(
+                extension_size=2,
+                output_extension_init="net2wider",
+                input_extension_init="net2wider",
+                rescaling="default_vt",
+            )
+
+    def test_rejects_unequal_extension_sizes(self) -> None:
+        _, second = self._make_pair()
+        with self.assertRaisesRegex(ValueError, "equal input and output"):
+            second.create_layer_extensions(
+                extension_size=2,
+                output_extension_size=2,
+                input_extension_size=3,
+                output_extension_init="net2wider",
+                input_extension_init="net2wider",
+            )
+
+    def test_probe_oracle_cross_check_injected_indices(self) -> None:
+        first, second = self._make_pair(bias=True)
+        x = torch.randn(12, first.in_features, device=self.device)
+        selected = torch.tensor([1, 0, 1], dtype=torch.long)
+
+        wa0 = first.weight.detach().clone()
+        ba0 = first.bias.detach().clone() if first.bias is not None else None
+        wb0 = second.weight.detach().clone()
+
+        with torch.no_grad():
+            y_before = second(first(x)).clone()
+
+        wa_ref, ba_ref, wb_ref = _oracle_widen_linear(wa0, ba0, wb0, selected)
+        bb0 = second.bias.detach().clone() if second.bias is not None else None
+        with torch.no_grad():
+            h_ref = torch.nn.functional.linear(x, wa_ref, ba_ref)
+            y_ref = torch.nn.functional.linear(h_ref, wb_ref, bb0)
+
+        second.create_layer_extensions(
+            extension_size=3,
+            output_extension_init="net2wider",
+            input_extension_init="net2wider",
+            selected_indices=selected,
+        )
+        second.apply_change(scaling_factor=1.0, extension_size=3)
+        second.delete_update(include_previous=True)
+
+        with torch.no_grad():
+            y_gromo = second(first(x))
+
+        self.assertAllClose(y_before, y_gromo, atol=FP_ATOL)
+        self.assertAllClose(y_ref, y_gromo, atol=FP_ATOL)
+        self.assertAllClose(first.weight, wa_ref, atol=1e-6)
+        self.assertAllClose(second.weight, wb_ref, atol=1e-6)
+
+    def test_complete_growth_entry_point(self) -> None:
+        first, second = self._make_pair(hidden=4)
+        second.target_in_neurons = 7
+        x = torch.randn(8, first.in_features, device=self.device)
+        with torch.no_grad():
+            y_before = second(first(x)).clone()
+
+        selected = torch.tensor([0, 3, 1], dtype=torch.long)
+        second.complete_growth(
+            {
+                "output_extension_init": "net2wider",
+                "input_extension_init": "net2wider",
+                "selected_indices": selected,
+            }
+        )
+        with torch.no_grad():
+            y_after = second(first(x))
+        self.assertAllClose(y_before, y_after, atol=FP_ATOL)
+        self.assertEqual(second.in_features, 7)
+
+
+class TestNet2WiderConvSmoke(TorchTestCase):
+    """Conv→Conv joint path smoke (groups==1; BN/residual out of scope)."""
+
+    def setUp(self) -> None:
+        torch.manual_seed(1)
+        self.device = global_device()
+
+    def _make_pair(self) -> tuple[FullConv2dGrowingModule, FullConv2dGrowingModule]:
+        first = FullConv2dGrowingModule(
+            in_channels=2,
+            out_channels=3,
+            kernel_size=3,
+            padding=1,
+            use_bias=True,
+            device=self.device,
+            name="conv1",
+        )
+        second = FullConv2dGrowingModule(
+            in_channels=3,
+            out_channels=4,
+            kernel_size=3,
+            padding=1,
+            use_bias=True,
+            device=self.device,
+            name="conv2",
+            previous_module=first,
+        )
+        return first, second
+
+    def test_function_preservation_eval_mode(self) -> None:
+        first, second = self._make_pair()
+        x = torch.randn(2, 2, 8, 8, device=self.device)
+        selected = torch.tensor([0, 2], dtype=torch.long)
+
+        first.eval()
+        second.eval()
+        with torch.no_grad():
+            y_before = second(first(x)).clone()
+
+        second.create_layer_extensions(
+            extension_size=2,
+            output_extension_init="net2wider",
+            input_extension_init="net2wider",
+            selected_indices=selected,
+        )
+        first.scaling_factor = 1.0  # type: ignore[assignment]
+        second.scaling_factor = 1.0  # type: ignore[assignment]
+        with torch.no_grad():
+            h, h_ext = first.extended_forward(x)
+            y_pre, y_ext = second.extended_forward(h, h_ext)
+        assert y_ext is None
+        self.assertAllClose(y_before, y_pre, atol=FP_ATOL)
+
+        second.apply_change(scaling_factor=1.0, extension_size=2)
+        second.delete_update(include_previous=True)
+        with torch.no_grad():
+            y_post = second(first(x))
+        self.assertAllClose(y_before, y_post, atol=FP_ATOL)
+
+    def test_groups_assert(self) -> None:
+        first, second = self._make_pair()
+        # Simulate grouped conv without relying on constructor support.
+        object.__setattr__(first.layer, "groups", 2)
+        with self.assertRaisesRegex(ValueError, "groups==1"):
+            second.create_layer_extensions(
+                extension_size=1,
+                output_extension_init="net2wider",
+                input_extension_init="net2wider",
+                selected_indices=torch.tensor([0]),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add a **joint** `net2wider` path in `GrowingModule.create_layer_extensions` that samples a shared replica map once, fills the previous layer's output extension, and scales the next layer's existing fan-in (and copies) by `1/c_j`.
- Reject output-only / kaiming mixes, `neuron_pairing`, `rescaling`, unequal extension sizes, and Conv `groups != 1`.
- Expose `selected_indices` / `generator` for probe↔gromo cross-checks; cherry-pick Linear extension device/dtype alignment from prior art.
- Scope for this PR: **Linear-only / BN-free** mechanism bar (Conv→Conv smoke without BN). GrowingBatchNorm replica plumbing and ResNet skip/stage-width growth are **out of scope**.

Supersedes prior-art `codex/feat-net2wider` / `neurips2026/net2net_support` (those scaled the wrong side / fell back to kaiming on input).

## Test plan
- [x] `pytest tests/test_net2wider_initializer.py` — Linear FP ≤ 1e-4 pre+post `apply_change`, two-step cumulative growth, pairing/rescaling/one-sided rejection, injected-index oracle cross-check, `complete_growth`, Conv smoke + `groups==1`
- [x] Related: `test_variance_transfer.py` + `TestCreateLayerExtensions` still green
- [ ] CI on this PR